### PR TITLE
Improve customer address management

### DIFF
--- a/resources/views/themes/xylo/layouts/header.blade.php
+++ b/resources/views/themes/xylo/layouts/header.blade.php
@@ -88,7 +88,9 @@
                     @guest('customer')
                         <li><a class="dropdown-item" href="{{ route('customer.login') }}">Sign In</a></li>
                         <li><a class="dropdown-item" href="{{ route('customer.register') }}">Sign Up</a></li>
-                    @elseauth('customer')
+                    @else
+                        <li><a class="dropdown-item" href="{{ route('customer.addresses.index') }}">{{ __('cms.customers.addresses') }}</a></li>
+                        <li><hr class="dropdown-divider"></li>
                         <li>
                             <a class="dropdown-item" href="{{ route('customer.logout') }}"
                                onclick="event.preventDefault(); document.getElementById('customer-logout-form').submit();">


### PR DESCRIPTION
## Summary
- ensure customer default address updates cascade across admin and storefront actions
- guarantee a fallback default address exists when creating or deleting customer addresses
- surface a quick link to the customer address book from the storefront account menu

## Testing
- `php artisan test` *(fails: vendor/autoload.php missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dee2bea30c83298463054756e6352f