### PR TITLE
Add admin customer creation page and translations

### DIFF
--- a/app/Http/Controllers/Admin/CustomerController.php
+++ b/app/Http/Controllers/Admin/CustomerController.php
@@ -75,13 +75,16 @@ class CustomerController extends Controller
                 $viewUrl = route('admin.customers.show', $customer);
                 $viewLabel = __('cms.customers.view_button');
                 $deleteLabel = __('cms.customers.delete_button');
+                $viewLabelEscaped = e($viewLabel);
+                $deleteLabelEscaped = e($deleteLabel);
 
                 return <<<HTML
                         <div class="btn-group btn-group-sm" role="group">
-                            <button type="button" class="btn btn-outline-primary" data-url="{$viewUrl}" title="{$viewLabel}">
+                            <button type="button" class="btn btn-outline-primary" data-url="{$viewUrl}" title="{$viewLabelEscaped}">
                                 <i class="bi bi-eye"></i>
+                                <span class="ms-1">{$viewLabelEscaped}</span>
                             </button>
-                            <button type="button" class="btn btn-outline-danger btn-delete-customer" data-id="{$customer->id}" title="{$deleteLabel}">
+                            <button type="button" class="btn btn-outline-danger btn-delete-customer" data-id="{$customer->id}" title="{$deleteLabelEscaped}">
                                 <i class="bi bi-trash-fill"></i>
                             </button>
                         </div>

--- a/resources/lang/ar/cms.php
+++ b/resources/lang/ar/cms.php
@@ -266,6 +266,12 @@ return [
     'customers' => [
         'customer_list' => 'قائمة العملاء',
 
+        // Create form
+        'create_title' => 'إنشاء عميل',
+        'create_description' => 'أضف عميلاً جديدًا عن طريق إدخال معلوماته الأساسية.',
+        'create_button' => 'إنشاء عميل',
+        'password' => 'كلمة المرور',
+
         // Table columns
         'id' => 'المعرف',
         'name' => 'الاسم',

--- a/resources/lang/de/cms.php
+++ b/resources/lang/de/cms.php
@@ -266,6 +266,12 @@ return [
     'customers' => [
         'customer_list' => 'Kundenliste',
 
+        // Create form
+        'create_title' => 'Kunde erstellen',
+        'create_description' => 'Fügen Sie einen neuen Kunden hinzu, indem Sie seine Basisdaten angeben.',
+        'create_button' => 'Kunde erstellen',
+        'password' => 'Passwort',
+
         // Table columns
         'id' => 'ID',
         'name' => 'Name',

--- a/resources/lang/en/cms.php
+++ b/resources/lang/en/cms.php
@@ -285,6 +285,12 @@ return [
     'customers' => [
         'customer_list' => 'Customer List',
 
+        // Create form
+        'create_title' => 'Create Customer',
+        'create_description' => 'Add a new customer by providing their basic information.',
+        'create_button' => 'Create Customer',
+        'password' => 'Password',
+
         // Table columns
         'id' => 'Id',
         'name' => 'Name',

--- a/resources/lang/es/cms.php
+++ b/resources/lang/es/cms.php
@@ -266,6 +266,12 @@ return [
     'customers' => [
         'customer_list' => 'Lista de clientes',
 
+        // Create form
+        'create_title' => 'Crear cliente',
+        'create_description' => 'Añade un nuevo cliente proporcionando su información básica.',
+        'create_button' => 'Crear cliente',
+        'password' => 'Contraseña',
+
         // Table columns
         'id' => 'ID',
         'name' => 'Nombre',

--- a/resources/lang/fa/cms.php
+++ b/resources/lang/fa/cms.php
@@ -266,6 +266,12 @@ return [
     'customers' => [
         'customer_list' => 'لیست مشتریان',
 
+        // Create form
+        'create_title' => 'ایجاد مشتری',
+        'create_description' => 'با وارد کردن اطلاعات پایه، مشتری جدیدی اضافه کنید.',
+        'create_button' => 'ایجاد مشتری',
+        'password' => 'رمز عبور',
+
         // Table columns
         'id' => 'شناسه',
         'name' => 'نام',

--- a/resources/lang/fr/cms.php
+++ b/resources/lang/fr/cms.php
@@ -266,6 +266,12 @@ return [
     'customers' => [
         'customer_list' => 'Liste des clients',
 
+        // Create form
+        'create_title' => 'Créer un client',
+        'create_description' => 'Ajoutez un nouveau client en renseignant ses informations de base.',
+        'create_button' => 'Créer un client',
+        'password' => 'Mot de passe',
+
         // Table columns
         'id' => 'ID',
         'name' => 'Nom',

--- a/resources/lang/hi/cms.php
+++ b/resources/lang/hi/cms.php
@@ -266,6 +266,12 @@ return [
     'customers' => [
         'customer_list' => 'ग्राहक सूची',
 
+        // Create form
+        'create_title' => 'ग्राहक बनाएं',
+        'create_description' => 'उनकी बुनियादी जानकारी देकर एक नया ग्राहक जोड़ें।',
+        'create_button' => 'ग्राहक बनाएं',
+        'password' => 'पासवर्ड',
+
         // Table columns
         'id' => 'आईडी',
         'name' => 'नाम',

--- a/resources/lang/id/cms.php
+++ b/resources/lang/id/cms.php
@@ -266,6 +266,12 @@ return [
     'customers' => [
         'customer_list' => 'Daftar Pelanggan',
 
+        // Create form
+        'create_title' => 'Buat Pelanggan',
+        'create_description' => 'Tambahkan pelanggan baru dengan memberikan informasi dasarnya.',
+        'create_button' => 'Buat Pelanggan',
+        'password' => 'Kata sandi',
+
         // Table columns
         'id' => 'ID',
         'name' => 'Nama',

--- a/resources/lang/it/cms.php
+++ b/resources/lang/it/cms.php
@@ -266,6 +266,12 @@ return [
     'customers' => [
         'customer_list' => 'Elenco Clienti',
 
+        // Create form
+        'create_title' => 'Crea cliente',
+        'create_description' => 'Aggiungi un nuovo cliente fornendo le sue informazioni di base.',
+        'create_button' => 'Crea cliente',
+        'password' => 'Password',
+
         // Table columns
         'id' => 'ID',
         'name' => 'Nome',

--- a/resources/lang/ja/cms.php
+++ b/resources/lang/ja/cms.php
@@ -266,6 +266,12 @@ return [
     'customers' => [
         'customer_list' => '顧客一覧',
 
+        // Create form
+        'create_title' => '顧客を作成',
+        'create_description' => '基本情報を入力して新しい顧客を追加します。',
+        'create_button' => '顧客を作成',
+        'password' => 'パスワード',
+
         // Table columns
         'id' => 'ID',
         'name' => '名前',

--- a/resources/lang/ko/cms.php
+++ b/resources/lang/ko/cms.php
@@ -266,6 +266,12 @@ return [
     'customers' => [
         'customer_list' => '고객 목록',
 
+        // Create form
+        'create_title' => '고객 생성',
+        'create_description' => '기본 정보를 입력하여 새로운 고객을 추가하세요.',
+        'create_button' => '고객 생성',
+        'password' => '비밀번호',
+
         // Table columns
         'id' => '아이디',
         'name' => '이름',

--- a/resources/lang/nl/cms.php
+++ b/resources/lang/nl/cms.php
@@ -265,6 +265,12 @@ return [
     'customers' => [
         'customer_list' => 'Klantlijst',
 
+        // Create form
+        'create_title' => 'Klant aanmaken',
+        'create_description' => 'Voeg een nieuwe klant toe door zijn basisinformatie in te vullen.',
+        'create_button' => 'Klant aanmaken',
+        'password' => 'Wachtwoord',
+
         // Table columns
         'id' => 'ID',
         'name' => 'Naam',

--- a/resources/lang/pl/cms.php
+++ b/resources/lang/pl/cms.php
@@ -266,6 +266,12 @@ return [
     'customers' => [
         'customer_list' => 'Lista klientów',
 
+        // Create form
+        'create_title' => 'Utwórz klienta',
+        'create_description' => 'Dodaj nowego klienta, podając jego podstawowe informacje.',
+        'create_button' => 'Utwórz klienta',
+        'password' => 'Hasło',
+
         // Table columns
         'id' => 'ID',
         'name' => 'Nazwa',

--- a/resources/lang/pt/cms.php
+++ b/resources/lang/pt/cms.php
@@ -265,6 +265,12 @@ return [
     'customers' => [
         'customer_list' => 'Lista de clientes',
 
+        // Create form
+        'create_title' => 'Criar cliente',
+        'create_description' => 'Adicione um novo cliente fornecendo suas informações básicas.',
+        'create_button' => 'Criar cliente',
+        'password' => 'Senha',
+
         // Table columns
         'id' => 'ID',
         'name' => 'Nome',

--- a/resources/lang/ru/cms.php
+++ b/resources/lang/ru/cms.php
@@ -266,6 +266,12 @@ return [
     'customers' => [
         'customer_list' => 'Список клиентов',
 
+        // Create form
+        'create_title' => 'Создать клиента',
+        'create_description' => 'Добавьте нового клиента, указав его основную информацию.',
+        'create_button' => 'Создать клиента',
+        'password' => 'Пароль',
+
         // Table columns
         'id' => 'ID',
         'name' => 'Имя',

--- a/resources/lang/th/cms.php
+++ b/resources/lang/th/cms.php
@@ -266,6 +266,12 @@ return [
     'customers' => [
         'customer_list' => 'รายชื่อลูกค้า',
 
+        // Create form
+        'create_title' => 'สร้างลูกค้า',
+        'create_description' => 'เพิ่มลูกค้าใหม่โดยกรอกข้อมูลพื้นฐานของลูกค้า',
+        'create_button' => 'สร้างลูกค้า',
+        'password' => 'รหัสผ่าน',
+
         // Table columns
         'id' => 'รหัส',
         'name' => 'ชื่อ',

--- a/resources/lang/tr/cms.php
+++ b/resources/lang/tr/cms.php
@@ -266,6 +266,12 @@ return [
     'customers' => [
         'customer_list' => 'Müşteri Listesi',
 
+        // Create form
+        'create_title' => 'Müşteri oluştur',
+        'create_description' => 'Temel bilgilerini girerek yeni bir müşteri ekleyin.',
+        'create_button' => 'Müşteri oluştur',
+        'password' => 'Parola',
+
         // Table columns
         'id' => 'ID',
         'name' => 'Adı',

--- a/resources/lang/vi/cms.php
+++ b/resources/lang/vi/cms.php
@@ -266,6 +266,12 @@ return [
     'customers' => [
         'customer_list' => 'Danh sách khách hàng',
 
+        // Create form
+        'create_title' => 'Tạo khách hàng',
+        'create_description' => 'Thêm khách hàng mới bằng cách cung cấp thông tin cơ bản của họ.',
+        'create_button' => 'Tạo khách hàng',
+        'password' => 'Mật khẩu',
+
         // Table columns
         'id' => 'ID',
         'name' => 'Tên',

--- a/resources/lang/zh/cms.php
+++ b/resources/lang/zh/cms.php
@@ -266,6 +266,12 @@ return [
     'customers' => [
         'customer_list' => '客户列表',
 
+        // Create form
+        'create_title' => '创建客户',
+        'create_description' => '通过提供基本信息添加新客户。',
+        'create_button' => '创建客户',
+        'password' => '密码',
+
         // Table columns
         'id' => '编号',
         'name' => '姓名',

--- a/resources/views/admin/customers/create.blade.php
+++ b/resources/views/admin/customers/create.blade.php
@@ -1,0 +1,88 @@
+@extends('admin.layouts.admin')
+
+@section('content')
+    <div class="card mt-4">
+        <div class="card-header card-header-bg text-white d-flex justify-content-between align-items-center">
+            <h6 class="mb-0">{{ __('cms.customers.create_title') }}</h6>
+            <button type="button" class="btn btn-light btn-sm"
+                    data-url="{{ route('admin.customers.index') }}">{{ __('cms.customers.back_to_list') }}</button>
+        </div>
+
+        <div class="card-body">
+            <p class="text-muted mb-4">{{ __('cms.customers.create_description') }}</p>
+
+            <form action="{{ route('admin.customers.store') }}" method="POST" class="row g-3">
+                @csrf
+
+                <div class="col-md-6">
+                    <label for="name" class="form-label">{{ __('cms.customers.name') }}</label>
+                    <input type="text" name="name" id="name"
+                           class="form-control @error('name') is-invalid @enderror"
+                           value="{{ old('name') }}" maxlength="255" required>
+                    @error('name')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+
+                <div class="col-md-6">
+                    <label for="email" class="form-label">{{ __('cms.customers.email') }}</label>
+                    <input type="email" name="email" id="email"
+                           class="form-control @error('email') is-invalid @enderror"
+                           value="{{ old('email') }}" maxlength="255" required>
+                    @error('email')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+
+                <div class="col-md-6">
+                    <label for="password" class="form-label">{{ __('cms.customers.password') }}</label>
+                    <input type="password" name="password" id="password"
+                           class="form-control @error('password') is-invalid @enderror" minlength="6" required>
+                    @error('password')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+
+                <div class="col-md-6">
+                    <label for="phone" class="form-label">{{ __('cms.customers.phone') }}</label>
+                    <input type="text" name="phone" id="phone"
+                           class="form-control @error('phone') is-invalid @enderror"
+                           value="{{ old('phone') }}" maxlength="20">
+                    @error('phone')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+
+                <div class="col-12">
+                    <label for="address" class="form-label">{{ __('cms.customers.address') }}</label>
+                    <textarea name="address" id="address" rows="3"
+                              class="form-control @error('address') is-invalid @enderror"
+                              maxlength="500">{{ old('address') }}</textarea>
+                    @error('address')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+
+                <div class="col-md-4">
+                    <label for="status" class="form-label">{{ __('cms.customers.status') }}</label>
+                    <select name="status" id="status"
+                            class="form-select @error('status') is-invalid @enderror" required>
+                        <option value="active" {{ old('status', 'active') === 'active' ? 'selected' : '' }}>
+                            {{ __('cms.customers.active') }}</option>
+                        <option value="inactive" {{ old('status') === 'inactive' ? 'selected' : '' }}>
+                            {{ __('cms.customers.inactive') }}</option>
+                    </select>
+                    @error('status')
+                        <div class="invalid-feedback">{{ $message }}</div>
+                    @enderror
+                </div>
+
+                <div class="col-12 d-flex gap-2">
+                    <button type="submit" class="btn btn-success">{{ __('cms.customers.create_button') }}</button>
+                    <button type="button" class="btn btn-secondary"
+                            data-url="{{ route('admin.customers.index') }}">{{ __('cms.customers.cancel_button') }}</button>
+                </div>
+            </form>
+        </div>
+    </div>
+@endsection

--- a/resources/views/admin/customers/index.blade.php
+++ b/resources/views/admin/customers/index.blade.php
@@ -2,8 +2,10 @@
 
 @section('content')
 <div class="card mt-4">
-    <div class="card-header card-header-bg text-white">
+    <div class="card-header card-header-bg text-white d-flex justify-content-between align-items-center">
         <h6 class="d-flex align-items-center mb-0 dt-heading">{{ __('cms.customers.customer_list') }}</h6>
+        <button type="button" class="btn btn-light btn-sm"
+                data-url="{{ route('admin.customers.create') }}">{{ __('cms.sidebar.customers.add_new') }}</button>
     </div>
     <div class="card-body">
         <table id="customers-table" class="table table-bordered mt-4 dt-style">


### PR DESCRIPTION
## Summary
- add an admin customer creation form with localized labels and navigation controls
- expose the create button from the customer list and improve the view action text
- translate the new customer form strings across supported languages

## Testing
- php artisan test *(fails: vendor/autoload.php is missing in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dee2b8a98c8329a7abc7bde138ae6d