### PR TITLE
Add feature tests covering admin page management workflows

### DIFF
--- a/app/Models/Language.php
+++ b/app/Models/Language.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Language extends Model
 {
+    use HasFactory;
+
     // Assume that you have an 'active' column in your languages table
     protected $fillable = ['name', 'code', 'translated_text', 'active'];
 

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Page extends Model
 {
+    use HasFactory;
+
     protected $fillable = ['slug', 'status'];
 
     public function translations()

--- a/app/Models/PageTranslation.php
+++ b/app/Models/PageTranslation.php
@@ -2,10 +2,13 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class PageTranslation extends Model
 {
+    use HasFactory;
+
     protected $fillable = ['page_id', 'language_code', 'title', 'content', 'image_url'];
 
     public function page()

--- a/database/factories/LanguageFactory.php
+++ b/database/factories/LanguageFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Language;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Language>
+ */
+class LanguageFactory extends Factory
+{
+    protected $model = Language::class;
+
+    public function definition(): array
+    {
+        $code = Str::lower($this->faker->unique()->lexify('??'));
+
+        return [
+            'name' => $this->faker->languageCode(),
+            'code' => $code,
+            'translated_text' => $this->faker->words(3, true),
+            'active' => true,
+        ];
+    }
+}

--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Page;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Page>
+ */
+class PageFactory extends Factory
+{
+    protected $model = Page::class;
+
+    public function definition(): array
+    {
+        $title = $this->faker->unique()->sentence(3);
+
+        return [
+            'slug' => Str::slug($title).'-'.$this->faker->unique()->numberBetween(1, 9999),
+            'status' => $this->faker->boolean(80),
+        ];
+    }
+}

--- a/database/factories/PageTranslationFactory.php
+++ b/database/factories/PageTranslationFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Page;
+use App\Models\PageTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\PageTranslation>
+ */
+class PageTranslationFactory extends Factory
+{
+    protected $model = PageTranslation::class;
+
+    public function definition(): array
+    {
+        return [
+            'page_id' => Page::factory(),
+            'language_code' => $this->faker->unique()->lexify('??'),
+            'title' => $this->faker->sentence(3),
+            'content' => $this->faker->paragraph(),
+            'image_url' => null,
+        ];
+    }
+}

--- a/tests/Feature/AdminPageManagementTest.php
+++ b/tests/Feature/AdminPageManagementTest.php
@@ -1,0 +1,225 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Language;
+use App\Models\Page;
+use App\Models\PageTranslation;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class AdminPageManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_view_pages_index(): void
+    {
+        $admin = User::factory()->create();
+        $page = Page::factory()->create();
+        PageTranslation::factory()->for($page)->create([
+            'language_code' => config('app.locale'),
+        ]);
+
+        $this->actingAs($admin);
+
+        $response = $this->get(route('admin.pages.index'));
+
+        $response
+            ->assertOk()
+            ->assertViewIs('admin.pages.index')
+            ->assertViewHas('pages', function ($pages) use ($page) {
+                return $pages->contains('id', $page->id);
+            });
+    }
+
+    public function test_admin_can_view_create_page_form(): void
+    {
+        $admin = User::factory()->create();
+        $language = Language::factory()->create(['code' => config('app.locale')]);
+
+        $this->actingAs($admin);
+
+        $response = $this->get(route('admin.pages.create'));
+
+        $response
+            ->assertOk()
+            ->assertViewIs('admin.pages.create')
+            ->assertViewHas('activeLanguages', function ($languages) use ($language) {
+                return $languages->contains('id', $language->id);
+            });
+    }
+
+    public function test_admin_can_store_new_page_with_translations(): void
+    {
+        Storage::fake('public');
+
+        $admin = User::factory()->create();
+        $defaultLocale = config('app.locale');
+        Language::factory()->create(['code' => $defaultLocale]);
+        Language::factory()->create(['code' => 'fr']);
+
+        $payload = [
+            'status' => 1,
+            'translations' => [
+                $defaultLocale => [
+                    'title' => 'About Us',
+                    'content' => 'Learn more about our journey.',
+                    'image' => UploadedFile::fake()->image('about.jpg'),
+                ],
+                'fr' => [
+                    'title' => 'À propos de nous',
+                    'content' => 'En savoir plus sur notre parcours.',
+                    'image' => UploadedFile::fake()->image('a-propos.jpg'),
+                ],
+            ],
+        ];
+
+        $this->actingAs($admin);
+
+        $response = $this->post(route('admin.pages.store'), $payload);
+
+        $response->assertRedirect(route('admin.pages.index'));
+
+        $page = Page::where('slug', 'about-us')->first();
+        $this->assertNotNull($page);
+        $this->assertDatabaseHas('pages', [
+            'id' => $page->id,
+            'status' => 1,
+        ]);
+
+        $translations = PageTranslation::where('page_id', $page->id)->get();
+        $this->assertCount(2, $translations);
+
+        foreach ($translations as $translation) {
+            $this->assertDatabaseHas('page_translations', [
+                'page_id' => $page->id,
+                'language_code' => $translation->language_code,
+                'title' => $translation->title,
+            ]);
+
+            if ($translation->image_url) {
+                Storage::disk('public')->assertExists($translation->image_url);
+            }
+        }
+    }
+
+    public function test_admin_can_update_page_translations_and_status(): void
+    {
+        Storage::fake('public');
+
+        $admin = User::factory()->create();
+        $defaultLocale = config('app.locale');
+        Language::factory()->create(['code' => $defaultLocale]);
+
+        $page = Page::factory()->create(['status' => 1, 'slug' => 'about-us']);
+        Storage::disk('public')->put('pages/old-image.jpg', 'old-image');
+        PageTranslation::factory()->for($page)->create([
+            'language_code' => $defaultLocale,
+            'title' => 'Old Title',
+            'content' => 'Old content',
+            'image_url' => 'pages/old-image.jpg',
+        ]);
+
+        $payload = [
+            'status' => 0,
+            'translations' => [
+                $defaultLocale => [
+                    'title' => 'New Title',
+                    'content' => 'Updated content for the page.',
+                    'image' => UploadedFile::fake()->image('new-image.jpg'),
+                ],
+            ],
+        ];
+
+        $this->actingAs($admin);
+
+        $response = $this->put(route('admin.pages.update', $page), $payload);
+
+        $response->assertRedirect(route('admin.pages.index'));
+
+        $this->assertDatabaseHas('pages', [
+            'id' => $page->id,
+            'status' => 0,
+        ]);
+
+        $translation = PageTranslation::where('page_id', $page->id)
+            ->where('language_code', $defaultLocale)
+            ->first();
+
+        $this->assertNotNull($translation);
+        $this->assertSame('New Title', $translation->title);
+        $this->assertSame('Updated content for the page.', $translation->content);
+        $this->assertNotNull($translation->image_url);
+
+        Storage::disk('public')->assertMissing('pages/old-image.jpg');
+        Storage::disk('public')->assertExists($translation->image_url);
+    }
+
+    public function test_admin_can_delete_page(): void
+    {
+        $admin = User::factory()->create();
+        $page = Page::factory()->create();
+        PageTranslation::factory()->for($page)->create([
+            'language_code' => config('app.locale'),
+        ]);
+
+        $this->actingAs($admin);
+
+        $response = $this->delete(route('admin.pages.destroy', $page));
+
+        $response
+            ->assertOk()
+            ->assertJson([
+                'success' => true,
+            ]);
+
+        $this->assertDatabaseMissing('pages', ['id' => $page->id]);
+        $this->assertDatabaseMissing('page_translations', ['page_id' => $page->id]);
+    }
+
+    public function test_admin_can_update_page_status_via_ajax(): void
+    {
+        $admin = User::factory()->create();
+        $page = Page::factory()->create(['status' => 1]);
+
+        $this->actingAs($admin);
+
+        $response = $this->postJson(route('admin.pages.updateStatus'), [
+            'id' => $page->id,
+            'status' => 0,
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJson([
+                'success' => true,
+            ]);
+
+        $this->assertFalse($page->fresh()->status);
+    }
+
+    public function test_pages_datatable_returns_page_data(): void
+    {
+        $admin = User::factory()->create();
+        $page = Page::factory()->create();
+        PageTranslation::factory()->for($page)->create([
+            'language_code' => config('app.locale'),
+            'title' => 'About Us',
+        ]);
+
+        $this->actingAs($admin);
+
+        $response = $this->postJson(route('admin.pages.data'), [
+            'draw' => 1,
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJsonFragment([
+                'translated_title' => 'About Us',
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add model factories for languages, pages, and page translations to support testing
- enable factories on the related models
- cover admin page management flows with feature tests, including CRUD, datatable, and status updates

## Testing
- not run (composer install requires GitHub token)

------
https://chatgpt.com/codex/tasks/task_e_68dee324bcf88329aa7b504b16692d8c