### PR TITLE
Refactor admin attribute management views

### DIFF
--- a/resources/views/admin/attributes/create.blade.php
+++ b/resources/views/admin/attributes/create.blade.php
@@ -1,193 +1,21 @@
 @extends('admin.layouts.admin')
-@section('title', 'Create Attribute')
+@section('title', __('cms.attributes.title_create'))
 
 @section('content')
-<div class="container mt-4">
-    <div class="card">
-        <div class="card-header card-header-bg text-white">
-            <h6>{{ __('cms.attributes.title_create') }}</h6>
-        </div>
-        <div class="card-body">
-            <form action="{{ route('admin.attributes.store') }}" method="POST">
-                @csrf
-                <!-- Attribute Name -->
-                <div class="mb-3">
-                    <label for="name" class="form-label">{{ __('cms.attributes.attribute_name') }}</label>
-                    <input type="text" 
-                           name="name" 
-                           id="name" 
-                           class="form-control @error('name') is-invalid @enderror" 
-                           value="{{ old('name') }}">
-                    @error('name')
-                        <div class="invalid-feedback">{{ $message }}</div>
-                    @enderror
-                </div>
+<x-admin.page-header :title="__('cms.attributes.title_create')">
+    <x-admin.button-link href="{{ route('admin.attributes.index') }}" class="btn-outline">
+        {{ __('cms.attributes.cancel') }}
+    </x-admin.button-link>
+</x-admin.page-header>
 
-                <!-- Dynamic Attribute Values -->
-                <div class="mb-3">
-                    <label class="form-label">{{ __('cms.attributes.attribute_values') }}</label>
-                    <div id="attribute-values-container">
-                        @php
-                            $oldValues = old('values', ['']); // at least 1 input
-                        @endphp
-                        @foreach ($oldValues as $index => $val)
-                            <div class="input-group mb-2 value-group">
-                                <input type="text" 
-                                       name="values[]" 
-                                       class="form-control @error('values.' . $index) is-invalid @enderror" 
-                                       value="{{ $val }}" 
-                                       placeholder="Enter value {{ $index }}">
-                                <button type="button" class="btn btn-danger remove-value">{{ __('cms.attributes.remove_value') }}</button>
-                                @error('values.' . $index)
-                                    <div class="invalid-feedback d-block">{{ $message }}</div>
-                                @enderror
-                            </div>
-                        @endforeach
-                    </div>
-                    <button type="button" id="add-value" class="btn btn-primary mt-2">{{ __('cms.attributes.add_value') }}</button>
-                </div>
-
-                <!-- Translations Section -->
-                <div class="mb-3">
-                    <label class="form-label">{{ __('cms.attributes.translations') }}</label>
-                    <ul class="nav nav-tabs" id="languageTabs" role="tablist">
-                        @foreach ($languages as $language)
-                            <li class="nav-item" role="presentation">
-                                <button class="nav-link {{ $loop->first ? 'active' : '' }}" 
-                                        id="{{ $language->code }}-tab" 
-                                        data-bs-toggle="tab" 
-                                        data-bs-target="#{{ $language->code }}" 
-                                        type="button">
-                                    {{ ucwords($language->name) }}
-                                </button>
-                            </li>
-                        @endforeach
-                    </ul>
-                    <div class="tab-content mt-3" id="languageTabContent">
-                        @foreach ($languages as $language)
-                            @php
-                                $oldTranslations = old("translations.{$language->code}", array_fill(0, count($oldValues), ''));
-                            @endphp
-                            <div class="tab-pane fade show {{ $loop->first ? 'active' : '' }}" id="{{ $language->code }}">
-                                <div id="translation-container-{{ $language->code }}">
-                                    @foreach ($oldTranslations as $tIndex => $tVal)
-                                        <div class="input-group mb-2 translation-group">
-                                            <input type="text" 
-                                                   name="translations[{{ $language->code }}][]" 
-                                                   class="form-control @error('translations.' . $language->code . '.' . $tIndex) is-invalid @enderror" 
-                                                   value="{{ $tVal }}" 
-                                                   placeholder="Enter {{ $language->name }} value {{ $tIndex }}">
-                                            @error('translations.' . $language->code . '.' . $tIndex)
-                                                <div class="invalid-feedback d-block">{{ $message }}</div>
-                                            @enderror
-                                        </div>
-                                    @endforeach
-                                </div>
-                            </div>
-                        @endforeach
-                    </div>
-                </div>
-
-                <!-- Submit Button -->
-                <button type="submit" class="btn btn-success mt-3">{{ __('cms.attributes.save_attribute') }}</button>
-            </form>
-        </div>
-    </div>
-</div>
+@include('admin.attributes.partials.form', [
+    'action' => route('admin.attributes.store'),
+    'method' => 'POST',
+    'languages' => $languages,
+    'submitLabel' => __('cms.attributes.save_attribute'),
+])
 @endsection
 
 @section('js')
-<script>
-document.addEventListener("DOMContentLoaded", function () {
-    @if ($errors->any())
-        var firstErrorElement = document.querySelector('.is-invalid');
-        if (firstErrorElement) {
-            var tabPane = firstErrorElement.closest('.tab-pane');
-            if (tabPane) {
-                var tabId = tabPane.getAttribute('id');
-                var triggerEl = document.querySelector(`button[data-bs-target="#${tabId}"]`);
-                if (triggerEl) {
-                    var tab = new bootstrap.Tab(triggerEl);
-                    tab.show();
-                }
-            }
-        }
-    @endif
-});
-</script>
-<script>
-document.addEventListener("DOMContentLoaded", function () {
-    let removeText = "{{ __('cms.attributes.remove_value') }}";
-    let languages = @json($languages->pluck('code')->toArray());
-    let languageNames = @json($languages->pluck('name')->toArray());
-
-    function updatePlaceholders() {
-        let valueGroups = document.querySelectorAll("#attribute-values-container .value-group input");
-        valueGroups.forEach((input, i) => {
-            input.placeholder = "Enter value " + i;
-        });
-
-        languages.forEach((lang, index) => {
-            let translationInputs = document.querySelectorAll("#translation-container-" + lang + " .translation-group input");
-            translationInputs.forEach((input, i) => {
-                input.placeholder = "Enter " + languageNames[index] + " value " + i;
-            });
-        });
-    }
-
-    document.getElementById("add-value").addEventListener("click", function () {
-        let container = document.getElementById("attribute-values-container");
-        let newValueGroup = document.createElement("div");
-        newValueGroup.classList.add("input-group", "mb-2", "value-group");
-
-        let valueInput = document.createElement("input");
-        valueInput.type = "text";
-        valueInput.name = "values[]";
-        valueInput.classList.add("form-control");
-
-        let removeValueBtn = document.createElement("button");
-        removeValueBtn.type = "button";
-        removeValueBtn.classList.add("btn", "btn-danger", "remove-value");
-        removeValueBtn.textContent = removeText;
-
-        newValueGroup.appendChild(valueInput);
-        newValueGroup.appendChild(removeValueBtn);
-        container.appendChild(newValueGroup);
-
-        languages.forEach((lang, index) => {
-            let containerLang = document.getElementById("translation-container-" + lang);
-            let newTranslationGroup = document.createElement("div");
-            newTranslationGroup.classList.add("input-group", "mb-2", "translation-group");
-
-            let input = document.createElement("input");
-            input.type = "text";
-            input.name = `translations[${lang}][]`;
-            input.classList.add("form-control");
-
-            newTranslationGroup.appendChild(input);
-            containerLang.appendChild(newTranslationGroup);
-        });
-
-        updatePlaceholders();
-    });
-
-    document.addEventListener("click", function(e) {
-        if(e.target && e.target.classList.contains("remove-value")){
-            let valueGroup = e.target.closest(".value-group");
-            let index = Array.from(document.querySelectorAll("#attribute-values-container .value-group")).indexOf(valueGroup);
-
-            if(valueGroup) valueGroup.remove();
-
-            languages.forEach(lang => {
-                let translations = document.querySelectorAll("#translation-container-" + lang + " .translation-group");
-                if(translations[index]) translations[index].remove();
-            });
-
-            updatePlaceholders();
-        }
-    });
-
-    updatePlaceholders();
-});
-</script>
+    @include('admin.attributes.partials.form-scripts', ['languages' => $languages])
 @endsection

--- a/resources/views/admin/attributes/edit.blade.php
+++ b/resources/views/admin/attributes/edit.blade.php
@@ -1,181 +1,22 @@
 @extends('admin.layouts.admin')
-
-@section('title', 'Edit Attribute')
+@section('title', __('cms.attributes.title_edit'))
 
 @section('content')
-<div class="container mt-4">
-    <div class="card">
-        <div class="card-header card-header-bg text-white">
-            <h6>{{ __('cms.attributes.title_edit') }}</h6>
-        </div>
-        <div class="card-body">
-            @if ($errors->any())
-                <div id="errorBar" class="alert alert-danger">
-                    <ul>
-                        @foreach ($errors->all() as $error)
-                            <li>{{ $error }}</li>
-                        @endforeach
-                    </ul>
-                </div>
-            @endif
+<x-admin.page-header :title="__('cms.attributes.title_edit')" :description="$attribute->name">
+    <x-admin.button-link href="{{ route('admin.attributes.index') }}" class="btn-outline">
+        {{ __('cms.attributes.cancel') }}
+    </x-admin.button-link>
+</x-admin.page-header>
 
-            <form action="{{ route('admin.attributes.update', $attribute->id) }}" method="POST">
-                @csrf
-                @method('PUT')
+@include('admin.attributes.partials.form', [
+    'action' => route('admin.attributes.update', $attribute->id),
+    'method' => 'PUT',
+    'languages' => $languages,
+    'attribute' => $attribute,
+    'submitLabel' => __('cms.attributes.update_attribute'),
+])
+@endsection
 
-                <!-- Attribute Name -->
-                <div class="mb-3">
-                    <label for="name" class="form-label">{{ __('cms.attributes.attribute_name') }}</label>
-                    <input type="text" 
-                           name="name" 
-                           id="name" 
-                           value="{{ old('name', $attribute->name) }}" 
-                           class="form-control @error('name') is-invalid @enderror" 
-                           required>
-                    @error('name')
-                        <div class="invalid-feedback">{{ $message }}</div>
-                    @enderror
-                </div>
-
-                <!-- Attribute Values -->
-                <div class="mb-3">
-                    <label class="form-label">{{ __('cms.attributes.attribute_values') }}</label>
-                    <div id="attribute-values-container">
-                        @foreach ($attribute->values as $value)
-                            <div class="input-group mb-2">
-                                <input type="text" 
-                                       name="values[]" 
-                                       value="{{ old('values.' . $loop->index, $value->value) }}" 
-                                       class="form-control">
-                                <button type="button" class="btn btn-danger remove-value">{{ __('cms.attributes.remove_value') }}</button>
-                            </div>
-                        @endforeach
-                    </div>
-                    <button type="button" id="add-value" class="btn btn-primary mt-2">{{ __('cms.attributes.add_value') }}</button>
-                </div>
-
-                <!-- Translations -->
-                <div class="mb-3">
-                    <label class="form-label">{{ __('cms.attributes.translations') }}</label>
-                    <ul class="nav nav-tabs" id="languageTabs" role="tablist">
-                        @foreach ($languages as $language)
-                            <li class="nav-item" role="presentation">
-                                <button class="nav-link {{ $loop->first ? 'active' : '' }}" 
-                                        id="{{ $language->code }}-tab"
-                                        data-bs-toggle="tab" 
-                                        data-bs-target="#{{ $language->code }}" 
-                                        type="button">
-                                    {{ ucwords($language->name) }}
-                                </button>
-                            </li>
-                        @endforeach
-                    </ul>
-
-                    <div class="tab-content mt-3" id="languageTabContent">
-                        @foreach ($languages as $language)
-                            <div class="tab-pane fade show {{ $loop->first ? 'active' : '' }}" id="{{ $language->code }}">
-                                <div id="translation-container-{{ $language->code }}">
-                                    @foreach ($attribute->values as $valueIndex => $value)
-                                        @php
-                                            $translation = $value->translations
-                                                ->where('language_code', $language->code)
-                                                ->first();
-                                        @endphp
-                                        <div class="input-group mb-2 translation-group">
-                                            <input type="text" 
-                                                   name="translations[{{ $language->code }}][]" 
-                                                   value="{{ old('translations.' . $language->code . '.' . $valueIndex, optional($translation)->translated_value) }}" 
-                                                   class="form-control" 
-                                                   placeholder="Enter {{ $language->name }} value">
-                                            <button type="button" class="btn btn-danger remove-translation">{{ __('cms.attributes.remove_value') }}</button>
-                                        </div>
-                                    @endforeach
-                                </div>
-                                <button type="button" class="btn btn-secondary add-translation mt-2"
-                                        data-lang="{{ $language->code }}">
-                                    {{ __('cms.attributes.add_value_translation') }}
-                                </button>
-                            </div>
-                        @endforeach
-                    </div>
-                </div>
-
-                <!-- Submit -->
-                <button type="submit" class="btn btn-success mt-3">{{ __('cms.attributes.update_attribute') }}</button>
-            </form>
-        </div>
-    </div>
-</div>
-
-<script>
-document.addEventListener("DOMContentLoaded", function () {
-    // Add new value
-    document.getElementById("add-value").addEventListener("click", function () {
-        let container = document.getElementById("attribute-values-container");
-        let newInputGroup = document.createElement("div");
-        newInputGroup.classList.add("input-group", "mb-2");
-
-        let input = document.createElement("input");
-        input.type = "text";
-        input.name = "values[]";
-        input.classList.add("form-control");
-        input.placeholder = "Enter value";
-
-        let removeBtn = document.createElement("button");
-        removeBtn.type = "button";
-        removeBtn.classList.add("btn", "btn-danger", "remove-value");
-        removeBtn.textContent = "Remove";
-        removeBtn.addEventListener("click", function () {
-            newInputGroup.remove();
-        });
-
-        newInputGroup.appendChild(input);
-        newInputGroup.appendChild(removeBtn);
-        container.appendChild(newInputGroup);
-    });
-
-    // Remove value
-    document.querySelectorAll(".remove-value").forEach(button => {
-        button.addEventListener("click", function () {
-            this.parentElement.remove();
-        });
-    });
-
-    // Add translation
-    document.querySelectorAll(".add-translation").forEach(button => {
-        button.addEventListener("click", function () {
-            let lang = this.dataset.lang;
-            let container = document.getElementById("translation-container-" + lang);
-
-            let newGroup = document.createElement("div");
-            newGroup.classList.add("input-group", "mb-2", "translation-group");
-
-            let input = document.createElement("input");
-            input.type = "text";
-            input.name = "translations[" + lang + "][]";
-            input.classList.add("form-control");
-            input.placeholder = "Enter " + lang + " value";
-
-            let removeBtn = document.createElement("button");
-            removeBtn.type = "button";
-            removeBtn.classList.add("btn", "btn-danger", "remove-translation");
-            removeBtn.textContent = "Remove";
-            removeBtn.addEventListener("click", function () {
-                newGroup.remove();
-            });
-
-            newGroup.appendChild(input);
-            newGroup.appendChild(removeBtn);
-            container.appendChild(newGroup);
-        });
-    });
-
-    // Remove translation
-    document.querySelectorAll(".remove-translation").forEach(button => {
-        button.addEventListener("click", function () {
-            this.parentElement.remove();
-        });
-    });
-});
-</script>
+@section('js')
+    @include('admin.attributes.partials.form-scripts', ['languages' => $languages])
 @endsection

--- a/resources/views/admin/attributes/index.blade.php
+++ b/resources/views/admin/attributes/index.blade.php
@@ -1,28 +1,26 @@
-
 @extends('admin.layouts.admin')
 
-@section('content')
+@section('title', __('cms.attributes.title_manage'))
 
-<div class="card mt-4">
-    <div class="card-header card-header-bg text-white">
-        <h6 class="d-flex align-items-center mb-0 dt-heading">{{ __('cms.attributes.title_manage') }}</h6>
-    </div>
-    <div class="card-body">
-        <table id="attributes-table" class="table table-bordered mt-4">
-            <thead>
-                <tr>
-                    <th>{{ __('cms.attributes.id') }}</th>
-                    <th>{{ __('cms.attributes.name') }}</th>
-                    <th>{{ __('cms.attributes.values') }}</th>
-                    <th>{{ __('cms.attributes.action') }}</th>
-                </tr>
-            </thead>
-        </table>
-    </div>
-</div>
+@section('content')
+<x-admin.page-header :title="__('cms.attributes.title_manage')">
+    <x-admin.button-link href="{{ route('admin.attributes.create') }}" class="btn-primary">
+        {{ __('cms.attributes.title_create') }}
+    </x-admin.button-link>
+</x-admin.page-header>
+
+<x-admin.card class="mt-6">
+    <x-admin.table id="attributes-table" :columns="[
+        __('cms.attributes.id'),
+        __('cms.attributes.name'),
+        __('cms.attributes.values'),
+        __('cms.attributes.action'),
+    ]">
+    </x-admin.table>
+</x-admin.card>
 
 <div class="modal fade" id="deleteAttributeModal" tabindex="-1" aria-labelledby="deleteAttributeModalLabel" aria-hidden="true">
-    <div class="modal-dialog">
+    <div class="modal-dialog modal-dialog-centered">
         <div class="modal-content">
             <div class="modal-header">
                 <h5 class="modal-title" id="deleteAttributeModalLabel">{{ __('cms.attributes.confirm_delete') }}</h5>
@@ -36,108 +34,124 @@
         </div>
     </div>
 </div>
-
 @endsection
 
-@section('js')
 @php
-    $datatableLang = __('cms.datatables'); 
+    $datatableLang = __('cms.datatables');
 @endphp
-<script>
-    $(document).ready(function() {
-        $('#attributes-table').DataTable({
-            processing: true,
-            serverSide: true,
-            ajax: {
-                url: "{{ route('admin.attributes.data') }}",
-                type: 'POST',
-                data: function(d) {
-                    d._token = "{{ csrf_token() }}";
-                }
-            },
-            columns: [
-                { data: 'id', name: 'id' },
-                { data: 'name', name: 'name' },
-                { data: 'values', name: 'values', orderable: false, searchable: false },
-                {
-                    data: 'action',
-                    orderable: false,
-                    searchable: false,
-                    render: function(data, type, row) {
-                        var editUrl = '{{ route('admin.attributes.edit', ':id') }}'.replace(':id', row.id);
-                        return `
-                            <div class="btn-group btn-group-sm" role="group">
-                                <button type="button" class="btn btn-outline-primary btn-edit-attribute" data-url="${editUrl}">
-                                    <i class="bi bi-pencil-fill"></i>
-                                </button>
-                                <button type="button" class="btn btn-outline-danger btn-delete-attribute" data-id="${row.id}">
-                                    <i class="bi bi-trash-fill"></i>
-                                </button>
-                            </div>
-                        `;
-                    }
-                }
-            ],
-            pageLength: 10,
-            language: {!! json_encode($datatableLang) !!}
-        });
-    });
 
-
-    let attributeToDeleteId = null;
-
-    $(document).on('click', '.btn-edit-attribute', function() {
-        const url = $(this).data('url');
-        if (url) {
-            window.location.href = url;
-        }
-    });
-
-    $(document).on('click', '.btn-delete-attribute', function() {
-        attributeToDeleteId = $(this).data('id');
-        $('#deleteAttributeModal').modal('show');
-    });
-
-    $('#confirmDeleteAttribute').off('click').on('click', function() {
-        if (attributeToDeleteId !== null) {
-            $.ajax({
-                url: '{{ route('admin.attributes.destroy', ':id') }}'.replace(':id', attributeToDeleteId),
-                method: 'DELETE',
-                data: {
-                    _token: "{{ csrf_token() }}",
+@section('js')
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const table = $('#attributes-table').DataTable({
+                processing: true,
+                serverSide: true,
+                ajax: {
+                    url: "{{ route('admin.attributes.data') }}",
+                    type: 'POST',
+                    data: function (data) {
+                        data._token = "{{ csrf_token() }}";
+                    },
                 },
-                success: function(response) {
-                    if (response.success) {
-                        $('#attributes-table').DataTable().ajax.reload();
-                        toastr.error(response.message, "Success", {
-                            closeButton: true,
-                            progressBar: true,
-                            positionClass: "toast-top-right",
-                            timeOut: 5000
-                        });
-                        $('#deleteAttributeModal').modal('hide');
-                    } else {
-                        toastr.error(response.message, "Error", {
-                            closeButton: true,
-                            progressBar: true,
-                            positionClass: "toast-top-right",
-                            timeOut: 5000
-                        });
-                    }
-                },
-                error: function() {
-                    toastr.error("Error deleting attribute! Please try again.", "Error", {
-                        closeButton: true,
-                        progressBar: true,
-                        positionClass: "toast-top-right",
-                        timeOut: 5000
-                    });
-                    $('#deleteAttributeModal').modal('hide');
+                columns: [
+                    { data: 'id', name: 'id' },
+                    { data: 'name', name: 'name' },
+                    { data: 'values', name: 'values', orderable: false, searchable: false },
+                    {
+                        data: 'action',
+                        orderable: false,
+                        searchable: false,
+                        render: function (data, type, row) {
+                            const editUrl = "{{ route('admin.attributes.edit', ':id') }}".replace(':id', row.id);
+
+                            return `
+                                <div class="flex items-center gap-2">
+                                    <button type="button" class="btn btn-outline-primary btn-sm btn-edit-attribute" data-url="${editUrl}" aria-label="{{ __('cms.attributes.title_edit') }}">
+                                        <i class="bi bi-pencil-fill" aria-hidden="true"></i>
+                                    </button>
+                                    <button type="button" class="btn btn-outline-danger btn-sm btn-delete-attribute" data-id="${row.id}" aria-label="{{ __('cms.attributes.delete') }}">
+                                        <i class="bi bi-trash-fill" aria-hidden="true"></i>
+                                    </button>
+                                </div>
+                            `;
+                        },
+                    },
+                ],
+                pageLength: 10,
+                language: @json($datatableLang),
+            });
+
+            let attributeToDeleteId = null;
+            const deleteModalElement = document.getElementById('deleteAttributeModal');
+            const deleteModal = deleteModalElement ? new bootstrap.Modal(deleteModalElement) : null;
+            const confirmDeleteButton = document.getElementById('confirmDeleteAttribute');
+
+            $(document).on('click', '.btn-edit-attribute', function () {
+                const url = $(this).data('url');
+                if (url) {
+                    window.location.href = url;
                 }
             });
-        }
-    });
 
-</script>
+            $(document).on('click', '.btn-delete-attribute', function () {
+                attributeToDeleteId = $(this).data('id') ?? null;
+                if (deleteModal) {
+                    deleteModal.show();
+                }
+            });
 
+            if (confirmDeleteButton) {
+                confirmDeleteButton.addEventListener('click', () => {
+                    if (!attributeToDeleteId) {
+                        return;
+                    }
+
+                    $.ajax({
+                        url: '{{ route('admin.attributes.destroy', ':id') }}'.replace(':id', attributeToDeleteId),
+                        method: 'DELETE',
+                        data: {
+                            _token: '{{ csrf_token() }}',
+                        },
+                        success: function (response) {
+                            if (response.success) {
+                                table.ajax.reload(null, false);
+                                toastr.success(response.message, "{{ __('cms.attributes.success') }}", {
+                                    closeButton: true,
+                                    progressBar: true,
+                                    positionClass: 'toast-top-right',
+                                    timeOut: 5000,
+                                });
+                                attributeToDeleteId = null;
+                                if (deleteModal) {
+                                    deleteModal.hide();
+                                }
+                            } else {
+                                const message = response.message || 'Error deleting attribute! Please try again.';
+                                toastr.error(message, "{{ __('cms.attributes.confirm_delete') }}", {
+                                    closeButton: true,
+                                    progressBar: true,
+                                    positionClass: 'toast-top-right',
+                                    timeOut: 5000,
+                                });
+                            }
+                        },
+                        error: function () {
+                            toastr.error('Error deleting attribute! Please try again.', 'Error', {
+                                closeButton: true,
+                                progressBar: true,
+                                positionClass: 'toast-top-right',
+                                timeOut: 5000,
+                            });
+                        },
+                    });
+                });
+            }
+
+            if (deleteModalElement) {
+                deleteModalElement.addEventListener('hidden.bs.modal', () => {
+                    attributeToDeleteId = null;
+                });
+            }
+        });
+    </script>
 @endsection

--- a/resources/views/admin/attributes/partials/form-scripts.blade.php
+++ b/resources/views/admin/attributes/partials/form-scripts.blade.php
@@ -1,0 +1,193 @@
+@php
+    $languageMeta = $languages->map(fn ($language) => [
+        'code' => $language->code,
+        'name' => ucwords($language->name),
+    ])->values();
+@endphp
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const languages = @json($languageMeta);
+        const valueContainer = document.getElementById('attribute-values-container');
+        const addButton = document.getElementById('add-attribute-value');
+        const removeText = @json(__('cms.attributes.remove_value'));
+        const valuePlaceholder = @json(__('cms.attributes.attribute_values'));
+        const translationPlaceholder = @json(__('cms.attributes.translated_value'));
+
+        if (!valueContainer) {
+            return;
+        }
+
+        const updatePlaceholders = () => {
+            const rows = Array.from(valueContainer.querySelectorAll('.attribute-value-row'));
+            rows.forEach((row, index) => {
+                const input = row.querySelector('input[name="values[]"]');
+                if (input) {
+                    input.placeholder = `${valuePlaceholder} #${index + 1}`;
+                }
+            });
+
+            languages.forEach(({ code, name }) => {
+                const container = document.getElementById(`translation-container-${code}`);
+                if (!container) {
+                    return;
+                }
+
+                const inputs = container.querySelectorAll(`input[name="translations[${code}][]"]`);
+                inputs.forEach((input, index) => {
+                    input.placeholder = `${translationPlaceholder} (${name}) #${index + 1}`;
+                });
+            });
+        };
+
+        const addTranslationGroup = (code) => {
+            const container = document.getElementById(`translation-container-${code}`);
+            if (!container) {
+                return null;
+            }
+
+            const group = document.createElement('div');
+            group.className = 'translation-group';
+
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.name = `translations[${code}][]`;
+            input.className = 'form-control';
+
+            group.appendChild(input);
+            container.appendChild(group);
+
+            return group;
+        };
+
+        const addValueRow = () => {
+            const row = document.createElement('div');
+            row.className = 'attribute-value-row flex flex-col gap-2 md:flex-row md:items-start md:gap-3';
+
+            const inputWrapper = document.createElement('div');
+            inputWrapper.className = 'flex-1';
+
+            const input = document.createElement('input');
+            input.type = 'text';
+            input.name = 'values[]';
+            input.className = 'form-control';
+
+            inputWrapper.appendChild(input);
+            row.appendChild(inputWrapper);
+
+            const removeButton = document.createElement('button');
+            removeButton.type = 'button';
+            removeButton.className = 'btn btn-outline-danger attribute-value-remove self-start';
+            removeButton.textContent = removeText;
+
+            row.appendChild(removeButton);
+            valueContainer.appendChild(row);
+
+            languages.forEach(({ code }) => addTranslationGroup(code));
+            updatePlaceholders();
+        };
+
+        const clearSingleRow = (row) => {
+            const valueInput = row.querySelector('input[name="values[]"]');
+            if (valueInput) {
+                valueInput.value = '';
+            }
+
+            languages.forEach(({ code }) => {
+                const container = document.getElementById(`translation-container-${code}`);
+                if (!container) {
+                    return;
+                }
+
+                const groups = Array.from(container.querySelectorAll('.translation-group'));
+                groups.forEach((group, index) => {
+                    const input = group.querySelector(`input[name="translations[${code}][]"]`);
+                    if (index === 0) {
+                        if (input) {
+                            input.value = '';
+                        }
+                    } else {
+                        group.remove();
+                    }
+                });
+
+                if (groups.length === 0) {
+                    addTranslationGroup(code);
+                }
+            });
+
+            updatePlaceholders();
+        };
+
+        const removeValueRow = (row) => {
+            const rows = Array.from(valueContainer.querySelectorAll('.attribute-value-row'));
+            if (rows.length <= 1) {
+                clearSingleRow(row);
+                return;
+            }
+
+            const index = rows.indexOf(row);
+            if (index === -1) {
+                return;
+            }
+
+            row.remove();
+
+            languages.forEach(({ code }) => {
+                const container = document.getElementById(`translation-container-${code}`);
+                if (!container) {
+                    return;
+                }
+
+                const groups = Array.from(container.querySelectorAll('.translation-group'));
+                if (groups[index]) {
+                    groups[index].remove();
+                }
+            });
+
+            if (valueContainer.querySelectorAll('.attribute-value-row').length === 0) {
+                addValueRow();
+            } else {
+                updatePlaceholders();
+            }
+        };
+
+        valueContainer.addEventListener('click', (event) => {
+            const trigger = event.target.closest('.attribute-value-remove');
+            if (!trigger) {
+                return;
+            }
+
+            event.preventDefault();
+            const row = trigger.closest('.attribute-value-row');
+            if (row) {
+                removeValueRow(row);
+            }
+        });
+
+        if (addButton) {
+            addButton.addEventListener('click', () => {
+                addValueRow();
+            });
+        }
+
+        if (valueContainer.querySelectorAll('.attribute-value-row').length === 0) {
+            addValueRow();
+        } else {
+            updatePlaceholders();
+        }
+
+        @if ($errors->any())
+            const firstInvalid = document.querySelector('.is-invalid');
+            if (firstInvalid) {
+                const tabPane = firstInvalid.closest('.tab-pane');
+                if (tabPane && typeof bootstrap !== 'undefined') {
+                    const trigger = document.querySelector(`[data-bs-target="#${tabPane.id}"]`);
+                    if (trigger) {
+                        bootstrap.Tab.getOrCreateInstance(trigger).show();
+                    }
+                }
+            }
+        @endif
+    });
+</script>

--- a/resources/views/admin/attributes/partials/form.blade.php
+++ b/resources/views/admin/attributes/partials/form.blade.php
@@ -1,0 +1,150 @@
+@php
+    $isEdit = isset($attribute);
+
+    $values = old('values');
+    if (is_array($values)) {
+        $values = array_values($values);
+    } elseif ($isEdit) {
+        $values = $attribute->values->pluck('value')->toArray();
+    } else {
+        $values = [];
+    }
+
+    if (empty($values)) {
+        $values = [''];
+    }
+
+    $translations = [];
+    foreach ($languages as $language) {
+        $code = $language->code;
+        $languageTranslations = old("translations.{$code}");
+
+        if (is_array($languageTranslations)) {
+            $languageTranslations = array_values($languageTranslations);
+        } elseif ($isEdit) {
+            $languageTranslations = $attribute->values->map(function ($value) use ($code) {
+                return optional($value->translations->firstWhere('language_code', $code))->translated_value ?? '';
+            })->toArray();
+        } else {
+            $languageTranslations = [];
+        }
+
+        if (count($languageTranslations) > count($values)) {
+            $languageTranslations = array_slice($languageTranslations, 0, count($values));
+        }
+
+        $translations[$code] = array_pad($languageTranslations, count($values), '');
+    }
+
+    $formMethod = strtoupper($method ?? 'POST');
+@endphp
+
+<form method="POST" action="{{ $action }}" class="space-y-6">
+    @csrf
+    @if ($formMethod !== 'POST')
+        @method($formMethod)
+    @endif
+
+    <x-admin.card :title="__('cms.attributes.attribute_name')">
+        <div class="grid gap-4 md:grid-cols-2">
+            <div class="md:col-span-2">
+                <label for="name" class="form-label">{{ __('cms.attributes.attribute_name') }}</label>
+                <input
+                    type="text"
+                    name="name"
+                    id="name"
+                    value="{{ old('name', $attribute->name ?? '') }}"
+                    class="form-control @error('name') is-invalid @enderror"
+                >
+                @error('name')
+                    <div class="invalid-feedback d-block">{{ $message }}</div>
+                @enderror
+            </div>
+        </div>
+    </x-admin.card>
+
+    <x-admin.card :title="__('cms.attributes.attribute_values')">
+        <div id="attribute-values-container" class="space-y-3">
+            @foreach ($values as $index => $value)
+                <div class="attribute-value-row flex flex-col gap-2 md:flex-row md:items-start md:gap-3">
+                    <div class="flex-1">
+                        <input
+                            type="text"
+                            name="values[]"
+                            value="{{ $value }}"
+                            class="form-control @error('values.' . $index) is-invalid @enderror"
+                        >
+                        @error('values.' . $index)
+                            <div class="invalid-feedback d-block">{{ $message }}</div>
+                        @enderror
+                    </div>
+                    <button type="button" class="btn btn-outline-danger attribute-value-remove self-start">
+                        {{ __('cms.attributes.remove_value') }}
+                    </button>
+                </div>
+            @endforeach
+        </div>
+        <button type="button" id="add-attribute-value" class="btn btn-outline-primary mt-3">
+            {{ __('cms.attributes.add_value') }}
+        </button>
+    </x-admin.card>
+
+    <x-admin.card :title="__('cms.attributes.translations')">
+        <ul class="nav nav-tabs" id="languageTabs" role="tablist">
+            @foreach ($languages as $language)
+                <li class="nav-item" role="presentation">
+                    <button
+                        class="nav-link {{ $loop->first ? 'active' : '' }}"
+                        id="attribute-{{ $language->code }}-tab"
+                        data-bs-toggle="tab"
+                        data-bs-target="#attribute-{{ $language->code }}-panel"
+                        type="button"
+                        role="tab"
+                        aria-controls="attribute-{{ $language->code }}-panel"
+                        aria-selected="{{ $loop->first ? 'true' : 'false' }}"
+                    >
+                        {{ ucwords($language->name) }}
+                    </button>
+                </li>
+            @endforeach
+        </ul>
+        <div class="tab-content mt-3" id="languageTabContent">
+            @foreach ($languages as $language)
+                @php
+                    $code = $language->code;
+                @endphp
+                <div
+                    class="tab-pane fade show {{ $loop->first ? 'active' : '' }}"
+                    id="attribute-{{ $code }}-panel"
+                    role="tabpanel"
+                    aria-labelledby="attribute-{{ $code }}-tab"
+                >
+                    <div id="translation-container-{{ $code }}" class="space-y-3">
+                        @foreach ($translations[$code] as $translationIndex => $translationValue)
+                            <div class="translation-group">
+                                <input
+                                    type="text"
+                                    name="translations[{{ $code }}][]"
+                                    value="{{ $translationValue }}"
+                                    class="form-control @error('translations.' . $code . '.' . $translationIndex) is-invalid @enderror"
+                                >
+                                @error('translations.' . $code . '.' . $translationIndex)
+                                    <div class="invalid-feedback d-block">{{ $message }}</div>
+                                @enderror
+                            </div>
+                        @endforeach
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    </x-admin.card>
+
+    <div class="flex flex-col-reverse gap-3 md:flex-row md:items-center md:justify-end">
+        <x-admin.button-link href="{{ route('admin.attributes.index') }}" class="btn-outline">
+            {{ __('cms.attributes.cancel') }}
+        </x-admin.button-link>
+        <button type="submit" class="btn btn-success">
+            {{ $submitLabel }}
+        </button>
+    </div>
+</form>


### PR DESCRIPTION
## Summary
- replace the admin attribute index page with the shared page header, card, and table components while modernizing the delete workflow script
- rebuild the attribute create and edit screens around a reusable Blade partial for the form layout
- add a shared JavaScript partial to manage dynamic attribute values and translations in a consistent way

## Testing
- php artisan test *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68dee9e711208329a420b370055ed570