### PR TITLE
Refactor admin coupon management views

### DIFF
--- a/resources/views/admin/coupons/create.blade.php
+++ b/resources/views/admin/coupons/create.blade.php
@@ -4,58 +4,16 @@
     <div class="card mt-4">
         <div class="card-header card-header-bg text-white d-flex justify-content-between align-items-center">
             <h6 class="mb-0">{{ __('cms.coupons.create_title') }}</h6>
-            <button type="button" class="btn btn-light btn-sm"
-                    data-url="{{ route('admin.coupons.index') }}">{{ __('cms.coupons.back_to_list') }}</button>
+            <a href="{{ route('admin.coupons.index') }}" class="btn btn-light btn-sm">
+                {{ __('cms.coupons.back_to_list') }}
+            </a>
         </div>
         <div class="card-body">
-            @if ($errors->any())
-                <div class="alert alert-danger">
-                    <ul class="mb-0">
-                        @foreach ($errors->all() as $error)
-                            <li>{{ $error }}</li>
-                        @endforeach
-                    </ul>
-                </div>
-            @endif
-
-            @php
-                $expiresValue = old('expires_at') ? \Carbon\Carbon::parse(old('expires_at'))->format('Y-m-d\TH:i') : '';
-            @endphp
-
-            <form action="{{ route('admin.coupons.store') }}" method="POST">
-                @csrf
-                <div class="mb-3">
-                    <label for="code" class="form-label">{{ __('cms.coupons.code') }}</label>
-                    <input type="text" name="code" id="code" class="form-control" value="{{ old('code') }}"
-                           required>
-                </div>
-
-                <div class="mb-3">
-                    <label for="discount" class="form-label">{{ __('cms.coupons.discount') }}</label>
-                    <input type="number" name="discount" id="discount" class="form-control" value="{{ old('discount') }}"
-                           step="0.01" min="0" required>
-                    <small class="text-muted">{{ __('cms.coupons.discount_hint') }}</small>
-                </div>
-
-                <div class="mb-3">
-                    <label for="type" class="form-label">{{ __('cms.coupons.type') }}</label>
-                    <select name="type" id="type" class="form-select" required>
-                        <option value="percentage" {{ old('type') === 'percentage' ? 'selected' : '' }}>
-                            {{ __('cms.coupons.type_labels.percentage') }}</option>
-                        <option value="fixed" {{ old('type') === 'fixed' ? 'selected' : '' }}>
-                            {{ __('cms.coupons.type_labels.fixed') }}</option>
-                    </select>
-                </div>
-
-                <div class="mb-3">
-                    <label for="expires_at" class="form-label">{{ __('cms.coupons.expires_at') }}</label>
-                    <input type="datetime-local" name="expires_at" id="expires_at" class="form-control"
-                           value="{{ $expiresValue }}">
-                    <small class="text-muted">{{ __('cms.coupons.expiry_hint') }}</small>
-                </div>
-
-                <button type="submit" class="btn btn-primary">{{ __('cms.coupons.save') }}</button>
-            </form>
+            @include('admin.coupons.partials.form', [
+                'action' => route('admin.coupons.store'),
+                'method' => 'POST',
+                'submitLabel' => __('cms.coupons.save'),
+            ])
         </div>
     </div>
 @endsection

--- a/resources/views/admin/coupons/edit.blade.php
+++ b/resources/views/admin/coupons/edit.blade.php
@@ -4,62 +4,17 @@
     <div class="card mt-4">
         <div class="card-header card-header-bg text-white d-flex justify-content-between align-items-center">
             <h6 class="mb-0">{{ __('cms.coupons.edit_title') }}</h6>
-            <button type="button" class="btn btn-light btn-sm"
-                    data-url="{{ route('admin.coupons.index') }}">{{ __('cms.coupons.back_to_list') }}</button>
+            <a href="{{ route('admin.coupons.index') }}" class="btn btn-light btn-sm">
+                {{ __('cms.coupons.back_to_list') }}
+            </a>
         </div>
         <div class="card-body">
-            @if ($errors->any())
-                <div class="alert alert-danger">
-                    <ul class="mb-0">
-                        @foreach ($errors->all() as $error)
-                            <li>{{ $error }}</li>
-                        @endforeach
-                    </ul>
-                </div>
-            @endif
-
-            @php
-                $expiresValue = old('expires_at')
-                    ? \Carbon\Carbon::parse(old('expires_at'))->format('Y-m-d\TH:i')
-                    : optional($coupon->expires_at)->format('Y-m-d\TH:i');
-            @endphp
-
-            <form action="{{ route('admin.coupons.update', $coupon->id) }}" method="POST">
-                @csrf
-                @method('PUT')
-
-                <div class="mb-3">
-                    <label for="code" class="form-label">{{ __('cms.coupons.code') }}</label>
-                    <input type="text" name="code" id="code" class="form-control"
-                           value="{{ old('code', $coupon->code) }}" required>
-                </div>
-
-                <div class="mb-3">
-                    <label for="discount" class="form-label">{{ __('cms.coupons.discount') }}</label>
-                    <input type="number" name="discount" id="discount" class="form-control"
-                           value="{{ old('discount', $coupon->discount) }}" step="0.01" min="0" required>
-                    <small class="text-muted">{{ __('cms.coupons.discount_hint') }}</small>
-                </div>
-
-                <div class="mb-3">
-                    <label for="type" class="form-label">{{ __('cms.coupons.type') }}</label>
-                    <select name="type" id="type" class="form-select" required>
-                        <option value="percentage" {{ old('type', $coupon->type) === 'percentage' ? 'selected' : '' }}>
-                            {{ __('cms.coupons.type_labels.percentage') }}</option>
-                        <option value="fixed" {{ old('type', $coupon->type) === 'fixed' ? 'selected' : '' }}>
-                            {{ __('cms.coupons.type_labels.fixed') }}</option>
-                    </select>
-                </div>
-
-                <div class="mb-3">
-                    <label for="expires_at" class="form-label">{{ __('cms.coupons.expires_at') }}</label>
-                    <input type="datetime-local" name="expires_at" id="expires_at" class="form-control"
-                           value="{{ $expiresValue }}">
-                    <small class="text-muted">{{ __('cms.coupons.expiry_hint') }}</small>
-                </div>
-
-                <button type="submit" class="btn btn-primary">{{ __('cms.coupons.update') }}</button>
-            </form>
+            @include('admin.coupons.partials.form', [
+                'action' => route('admin.coupons.update', $coupon->id),
+                'method' => 'PUT',
+                'submitLabel' => __('cms.coupons.update'),
+                'coupon' => $coupon,
+            ])
         </div>
     </div>
 @endsection

--- a/resources/views/admin/coupons/partials/form.blade.php
+++ b/resources/views/admin/coupons/partials/form.blade.php
@@ -1,0 +1,105 @@
+@php
+    $formMethod = strtoupper($method ?? 'POST');
+    $couponModel = $coupon ?? null;
+
+    $expiresAtValue = old('expires_at');
+
+    if ($expiresAtValue) {
+        $expiresAtValue = \Illuminate\Support\Carbon::parse($expiresAtValue)->format('Y-m-d\\TH:i');
+    } elseif ($couponModel && $couponModel->expires_at) {
+        $expiresAtValue = $couponModel->expires_at->format('Y-m-d\\TH:i');
+    } else {
+        $expiresAtValue = '';
+    }
+
+    $typeValue = old('type', optional($couponModel)->type);
+@endphp
+
+@if ($errors->any())
+    <div class="alert alert-danger">
+        <ul class="mb-0">
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+
+<form action="{{ $action }}" method="POST">
+    @csrf
+    @if (!in_array($formMethod, ['GET', 'POST']))
+        @method($formMethod)
+    @endif
+
+    <div class="mb-3">
+        <label for="code" class="form-label">{{ __('cms.coupons.code') }}</label>
+        <input
+            type="text"
+            name="code"
+            id="code"
+            class="form-control @error('code') is-invalid @enderror"
+            value="{{ old('code', optional($couponModel)->code) }}"
+            required
+        >
+        @error('code')
+            <div class="invalid-feedback">{{ $message }}</div>
+        @enderror
+    </div>
+
+    <div class="mb-3">
+        <label for="discount" class="form-label">{{ __('cms.coupons.discount') }}</label>
+        <input
+            type="number"
+            name="discount"
+            id="discount"
+            class="form-control @error('discount') is-invalid @enderror"
+            value="{{ old('discount', optional($couponModel)->discount) }}"
+            step="0.01"
+            min="0"
+            required
+        >
+        @error('discount')
+            <div class="invalid-feedback">{{ $message }}</div>
+        @enderror
+        <small class="text-muted">{{ __('cms.coupons.discount_hint') }}</small>
+    </div>
+
+    <div class="mb-3">
+        <label for="type" class="form-label">{{ __('cms.coupons.type') }}</label>
+        <select
+            name="type"
+            id="type"
+            class="form-select @error('type') is-invalid @enderror"
+            required
+        >
+            <option value="percentage" {{ $typeValue === 'percentage' ? 'selected' : '' }}>
+                {{ __('cms.coupons.type_labels.percentage') }}
+            </option>
+            <option value="fixed" {{ $typeValue === 'fixed' ? 'selected' : '' }}>
+                {{ __('cms.coupons.type_labels.fixed') }}
+            </option>
+        </select>
+        @error('type')
+            <div class="invalid-feedback">{{ $message }}</div>
+        @enderror
+    </div>
+
+    <div class="mb-3">
+        <label for="expires_at" class="form-label">{{ __('cms.coupons.expires_at') }}</label>
+        <input
+            type="datetime-local"
+            name="expires_at"
+            id="expires_at"
+            class="form-control @error('expires_at') is-invalid @enderror"
+            value="{{ $expiresAtValue }}"
+        >
+        @error('expires_at')
+            <div class="invalid-feedback">{{ $message }}</div>
+        @enderror
+        <small class="text-muted">{{ __('cms.coupons.expiry_hint') }}</small>
+    </div>
+
+    <button type="submit" class="btn btn-primary">
+        {{ $submitLabel ?? __('cms.coupons.save') }}
+    </button>
+</form>


### PR DESCRIPTION
## Summary
- extract a shared coupon form partial with reusable validation and field formatting
- update the create and edit screens to consume the shared form and simplify navigation
- modernize the coupon index scripts by using the script stack, shared toast helpers, and cleaner modal handling

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dee9fb0dac8329bd655808893a4f1f