### PR TITLE
Refactor admin vendor management UI

### DIFF
--- a/resources/lang/en/cms.php
+++ b/resources/lang/en/cms.php
@@ -379,36 +379,70 @@ return [
     ],
 
     'vendors' => [
-        'title_list' => 'Vendor List',
-        'id' => 'Id',
-        'name' => 'Name',
+        // Titles & descriptions
+        'title_manage' => 'Manage Vendors',
+        'index_description' => 'Monitor vendor accounts, statuses, and onboarding progress.',
+        'title_create' => 'Register Vendor',
+        'create_description' => 'Create a vendor account with credentials and status controls.',
+        'table_title' => 'Vendor directory',
+        'back_to_index' => 'Back to vendors',
+
+        // Metrics
+        'total_vendors' => 'Total vendors',
+        'active_vendors' => 'Active vendors',
+        'inactive_vendors' => 'Inactive vendors',
+        'banned_vendors' => 'Banned vendors',
+
+        // Table columns
+        'id' => 'ID',
+        'name' => 'Vendor',
         'email' => 'Email',
         'phone' => 'Phone',
         'status' => 'Status',
         'actions' => 'Actions',
-        'register_new_vendor' => 'Register New Vendor',
-        'vendor_name' => 'Vendor Name',
-        'vendor_email' => 'Vendor Email',
-        'phone_optional' => 'Phone (Optional)',
+        'empty_state' => 'No vendors found yet.',
+
+        // Status labels
+        'status_active' => 'Active',
+        'status_inactive' => 'Inactive',
+        'status_banned' => 'Banned',
+        'status_unknown' => 'Unknown',
+
+        // Form labels
+        'vendor_details_heading' => 'Vendor details',
+        'account_security_heading' => 'Account security',
+        'vendor_name' => 'Vendor name',
+        'vendor_email' => 'Vendor email',
+        'phone_optional' => 'Phone (optional)',
         'password' => 'Password',
-        'confirm_password' => 'Confirm Password',
-        'status' => 'Status',
+        'confirm_password' => 'Confirm password',
+        'status_label' => 'Status',
+        'status_placeholder' => 'Select status',
+
+        // Buttons
+        'add_vendor' => 'Add Vendor',
+        'register_button' => 'Create vendor',
+        'cancel_button' => 'Cancel',
+        'delete_button' => 'Delete vendor',
+        'cancel' => 'Cancel',
+        'delete' => 'Delete',
+
+        // Modal copy
+        'modal_confirm_delete_title' => 'Delete vendor',
+        'modal_confirm_delete_body' => 'Are you sure you want to delete this vendor? This action cannot be undone.',
+        'confirm_delete_button' => 'Delete vendor',
+
+        // Notifications
+        'success_create' => 'Vendor registered successfully!',
+        'success_delete' => 'Vendor deleted successfully!',
+        'error_delete' => 'Error deleting vendor! Please try again.',
+
+        // Legacy keys kept for backwards compatibility
+        'title_list' => 'Vendor List',
+        'register_new_vendor' => 'Register New Vendor',
         'active' => 'Active',
         'inactive' => 'Inactive',
         'banned' => 'Banned',
-        'register_button' => 'Register Vendor',
-        'cancel_button' => 'Cancel',
-
-        'active' => 'Active',
-        'inactive' => 'Inactive',
-
-        'modal_confirm_delete_title' => 'Confirm Delete',
-        'modal_confirm_delete_body' => 'Are you sure you want to delete this vendor?',
-        'delete' => 'Delete',
-        'cancel' => 'Cancel',
-
-        'success' => 'Success',
-        'error_delete' => 'Error deleting vendor! Please try again.',
     ],
 
     'languages' => [

--- a/resources/views/admin/vendors/create.blade.php
+++ b/resources/views/admin/vendors/create.blade.php
@@ -1,79 +1,150 @@
 @extends('admin.layouts.admin')
 
+@php
+    $statusOptions = [
+        'active' => __('cms.vendors.status_active'),
+        'inactive' => __('cms.vendors.status_inactive'),
+        'banned' => __('cms.vendors.status_banned'),
+    ];
+@endphp
+
 @section('content')
-    <div class="card mt-4">
-        <div class="card-header card-header-bg text-white">
-            <h6 class="d-flex align-items-center mb-0 dt-heading">{{ __('cms.vendors.register_new_vendor') }}</h6>
+<x-admin.page-header
+    :title="__('cms.vendors.title_create')"
+    :description="__('cms.vendors.create_description')"
+>
+    <x-admin.button-link href="{{ route('admin.vendors.index') }}" class="btn-outline">
+        {{ __('cms.vendors.back_to_index') }}
+    </x-admin.button-link>
+</x-admin.page-header>
+
+<x-admin.card class="mt-6">
+    <form action="{{ route('admin.vendors.store') }}" method="POST" class="grid gap-6">
+        @csrf
+
+        <div class="grid gap-6 lg:grid-cols-2">
+            <div class="space-y-4">
+                <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">{{ __('cms.vendors.vendor_details_heading') }}</h3>
+
+                <div class="grid gap-4">
+                    <div>
+                        <label for="name" class="form-label">{{ __('cms.vendors.vendor_name') }}</label>
+                        <input
+                            id="name"
+                            type="text"
+                            name="name"
+                            value="{{ old('name') }}"
+                            maxlength="255"
+                            class="form-control @error('name') is-invalid @enderror"
+                            autocomplete="name"
+                            required
+                        >
+                        @error('name')
+                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div>
+                        <label for="email" class="form-label">{{ __('cms.vendors.vendor_email') }}</label>
+                        <input
+                            id="email"
+                            type="email"
+                            name="email"
+                            value="{{ old('email') }}"
+                            maxlength="255"
+                            class="form-control @error('email') is-invalid @enderror"
+                            autocomplete="email"
+                            required
+                        >
+                        @error('email')
+                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div>
+                        <label for="phone" class="form-label">{{ __('cms.vendors.phone_optional') }}</label>
+                        <input
+                            id="phone"
+                            type="text"
+                            name="phone"
+                            value="{{ old('phone') }}"
+                            maxlength="20"
+                            class="form-control @error('phone') is-invalid @enderror"
+                            autocomplete="tel"
+                            placeholder="+1 555 123 4567"
+                        >
+                        @error('phone')
+                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+                </div>
+            </div>
+
+            <div class="space-y-4">
+                <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">{{ __('cms.vendors.account_security_heading') }}</h3>
+
+                <div class="grid gap-4">
+                    <div>
+                        <label for="password" class="form-label">{{ __('cms.vendors.password') }}</label>
+                        <input
+                            id="password"
+                            type="password"
+                            name="password"
+                            class="form-control @error('password') is-invalid @enderror"
+                            autocomplete="new-password"
+                            required
+                        >
+                        @error('password')
+                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div>
+                        <label for="password_confirmation" class="form-label">{{ __('cms.vendors.confirm_password') }}</label>
+                        <input
+                            id="password_confirmation"
+                            type="password"
+                            name="password_confirmation"
+                            class="form-control @error('password_confirmation') is-invalid @enderror"
+                            autocomplete="new-password"
+                            required
+                        >
+                        @error('password_confirmation')
+                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div>
+                        <label for="status" class="form-label">{{ __('cms.vendors.status_label') }}</label>
+                        <select
+                            id="status"
+                            name="status"
+                            class="form-select @error('status') is-invalid @enderror"
+                            required
+                        >
+                            <option value="" disabled {{ old('status') ? '' : 'selected' }}>{{ __('cms.vendors.status_placeholder') }}</option>
+                            @foreach ($statusOptions as $value => $label)
+                                <option value="{{ $value }}" @selected(old('status', 'active') === $value)>
+                                    {{ $label }}
+                                </option>
+                            @endforeach
+                        </select>
+                        @error('status')
+                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+                </div>
+            </div>
         </div>
-        <div class="card-body">
-            <form action="{{ route('admin.vendors.store') }}" method="POST">
-                @csrf
 
-                <div class="mb-3">
-                    <label for="name" class="form-label">{{ __('cms.vendors.vendor_name') }}</label>
-                    <input type="text" name="name" class="form-control @error('name') is-invalid @enderror"
-                           value="{{ old('name') }}" maxlength="255">
-                    @error('name')
-                        <small class="text-danger">{{ $message }}</small>
-                    @enderror
-                </div>
-
-                <div class="mb-3">
-                    <label for="email" class="form-label">{{ __('cms.vendors.vendor_email') }}</label>
-                    <input type="email" name="email" class="form-control @error('email') is-invalid @enderror"
-                           value="{{ old('email') }}" maxlength="255">
-                    @error('email')
-                        <small class="text-danger">{{ $message }}</small>
-                    @enderror
-                </div>
-
-                <div class="mb-3">
-                    <label for="phone" class="form-label">{{ __('cms.vendors.phone_optional') }}</label>
-                    <input type="text" name="phone" class="form-control @error('phone') is-invalid @enderror"
-                           value="{{ old('phone') }}" maxlength="20">
-                    @error('phone')
-                        <small class="text-danger">{{ $message }}</small>
-                    @enderror
-                </div>
-
-                <div class="mb-3">
-                    <label for="password" class="form-label">{{ __('cms.vendors.password') }}</label>
-                    <input type="password" name="password"
-                           class="form-control @error('password') is-invalid @enderror" autocomplete="new-password">
-                    @error('password')
-                        <small class="text-danger">{{ $message }}</small>
-                    @enderror
-                </div>
-
-                <div class="mb-3">
-                    <label for="password_confirmation" class="form-label">{{ __('cms.vendors.confirm_password') }}</label>
-                    <input type="password" name="password_confirmation"
-                           class="form-control @error('password_confirmation') is-invalid @enderror"
-                           autocomplete="new-password">
-                    @error('password_confirmation')
-                        <small class="text-danger">{{ $message }}</small>
-                    @enderror
-                </div>
-
-                <div class="mb-3">
-                    <label for="status" class="form-label">{{ __('cms.vendors.status') }}</label>
-                    <select name="status" class="form-select @error('status') is-invalid @enderror">
-                        <option value="active" {{ old('status') == 'active' ? 'selected' : '' }}>
-                            {{ __('cms.vendors.active') }}</option>
-                        <option value="inactive" {{ old('status') == 'inactive' ? 'selected' : '' }}>
-                            {{ __('cms.vendors.inactive') }}</option>
-                        <option value="banned" {{ old('status') == 'banned' ? 'selected' : '' }}>
-                            {{ __('cms.vendors.banned') }}</option>
-                    </select>
-                    @error('status')
-                        <small class="text-danger">{{ $message }}</small>
-                    @enderror
-                </div>
-
-                <button type="submit" class="btn btn-success">{{ __('cms.vendors.register_button') }}</button>
-                <button type="button" class="btn btn-secondary"
-                        data-url="{{ route('admin.vendors.index') }}">{{ __('cms.vendors.cancel') }}</button>
-            </form>
+        <div class="flex flex-wrap justify-end gap-3">
+            <button type="submit" class="btn btn-primary">
+                {{ __('cms.vendors.register_button') }}
+            </button>
+            <x-admin.button-link href="{{ route('admin.vendors.index') }}" class="btn-outline">
+                {{ __('cms.vendors.cancel_button') }}
+            </x-admin.button-link>
         </div>
-    </div>
+    </form>
+</x-admin.card>
 @endsection


### PR DESCRIPTION
## Summary
- refactor the admin vendor index to use the new card, table, and modal patterns with vendor activity metrics
- redesign the vendor creation form with sectioned layout, reusable components, and translated messaging
- enhance the vendor controller and translations to supply stats, consistent status badges, and localized feedback

## Testing
- php artisan test *(fails: vendor/autoload.php is missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68deea37dafc8329a4b2536aa77b5edb