### PR TITLE
Refactor admin refunds interface

### DIFF
--- a/app/Http/Controllers/Admin/RefundController.php
+++ b/app/Http/Controllers/Admin/RefundController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\Refund;
 use Illuminate\Http\Request;
+use Illuminate\Support\Str;
 use Yajra\DataTables\Facades\DataTables;
 
 class RefundController extends Controller
@@ -17,10 +18,73 @@ class RefundController extends Controller
     public function getData(Request $request)
     {
         if ($request->ajax()) {
-            $refunds = Refund::with('payment')->select('refunds.*');
+            $refunds = Refund::with(['payment.gateway'])->select('refunds.*');
 
             return DataTables::of($refunds)
-                ->addColumn('payment', fn($row) => $row->payment ? 'Payment #' . $row->payment->id : '—')
+                ->editColumn('amount', fn($row) => number_format((float) $row->amount, 2))
+                ->editColumn('reason', function ($row) {
+                    if (! $row->reason) {
+                        return __('cms.refunds.not_available');
+                    }
+
+                    return Str::limit($row->reason, 80);
+                })
+                ->addColumn('payment', function ($row) {
+                    if (! $row->payment) {
+                        return '<span class="text-sm text-gray-400">' . e(__('cms.refunds.not_available')) . '</span>';
+                    }
+
+                    $payment = $row->payment;
+                    $amount = number_format((float) $payment->amount, 2);
+                    $statusClassMap = [
+                        'completed' => 'bg-emerald-50 text-emerald-700 ring-emerald-500/20',
+                        'pending' => 'bg-amber-50 text-amber-700 ring-amber-500/20',
+                        'failed' => 'bg-rose-50 text-rose-700 ring-rose-500/20',
+                    ];
+                    $statusKey = strtolower((string) $payment->status);
+                    $statusClass = $statusClassMap[$statusKey] ?? 'bg-gray-100 text-gray-700 ring-gray-500/10';
+                    $statusLabels = [
+                        'completed' => __('cms.payments.completed'),
+                        'pending' => __('cms.payments.pending'),
+                        'failed' => __('cms.payments.failed'),
+                    ];
+                    $statusLabel = $statusLabels[$statusKey] ?? ucfirst((string) $payment->status);
+                    $gateway = $payment->gateway?->name;
+                    $amountLabel = e(__('cms.payments.amount'));
+
+                    $statusBadge = '<span class="inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 text-[11px] font-medium ring-1 ' . $statusClass . '"><span class="h-1.5 w-1.5 rounded-full bg-current"></span>' . e($statusLabel) . '</span>';
+                    $gatewayMarkup = $gateway
+                        ? '<span class="text-[11px] text-gray-500">' . e(__('cms.payments.gateway')) . ': ' . e($gateway) . '</span>'
+                        : '';
+                    $paymentLabel = e(__('cms.refunds.payment'));
+
+                    return <<<HTML
+                        <div class="flex flex-col gap-1">
+                            <span class="text-sm font-semibold text-gray-900">{$paymentLabel} #{$payment->id}</span>
+                            <span class="text-[11px] text-gray-500">{$amountLabel}: {$amount}</span>
+                            {$statusBadge}
+                            {$gatewayMarkup}
+                        </div>
+                    HTML;
+                })
+                ->editColumn('status', function ($row) {
+                    $statusKey = strtolower((string) $row->status);
+                    $statusLabels = [
+                        'completed' => __('cms.refunds.completed'),
+                        'pending' => __('cms.refunds.pending'),
+                        'failed' => __('cms.refunds.failed'),
+                    ];
+                    $statusClassMap = [
+                        'completed' => 'bg-emerald-50 text-emerald-700 ring-emerald-500/20',
+                        'pending' => 'bg-amber-50 text-amber-700 ring-amber-500/20',
+                        'failed' => 'bg-rose-50 text-rose-700 ring-rose-500/20',
+                    ];
+
+                    $label = $statusLabels[$statusKey] ?? ucfirst($statusKey);
+                    $statusClass = $statusClassMap[$statusKey] ?? 'bg-gray-100 text-gray-700 ring-gray-500/10';
+
+                    return '<span class="inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-xs font-medium ring-1 ' . $statusClass . '"><span class="h-1.5 w-1.5 rounded-full bg-current"></span>' . e($label) . '</span>';
+                })
                 ->addColumn('action', function ($row) {
                     $showRoute = route('admin.refunds.show', $row->id);
                     $viewLabel = e(__('cms.messages.view_details'));
@@ -41,6 +105,7 @@ class RefundController extends Controller
                         </div>
                     HTML;
                 })
+                ->rawColumns(['payment', 'status', 'action'])
                 ->make(true);
         }
     }

--- a/resources/views/admin/refunds/index.blade.php
+++ b/resources/views/admin/refunds/index.blade.php
@@ -1,42 +1,69 @@
 @extends('admin.layouts.admin')
 
 @section('content')
-<div class="card mt-4">
-    <div class="card-header card-header-bg text-white">
-        <h6 class="d-flex align-items-center mb-0 dt-heading">{{ __('cms.refunds.title') }}</h6>
+<div class="max-w-7xl mx-auto mt-4 space-y-6">
+    <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+            <h1 class="text-2xl font-semibold text-gray-900">{{ __('cms.refunds.title') }}</h1>
+            <p class="mt-1 text-sm text-gray-500">{{ __('cms.refunds.manage') }}</p>
+        </div>
     </div>
 
-    <div class="card-body">
-        <table id="refunds-table" class="table table-bordered mt-4 dt-style">
-            <thead>
-                <tr>
-                    <th>{{ __('cms.refunds.id') }}</th>
-                    <th>{{ __('cms.refunds.payment') }}</th>
-                    <th>{{ __('cms.refunds.amount') }}</th>
-                    <th>{{ __('cms.refunds.status') }}</th>
-                    <th>{{ __('cms.refunds.reason') }}</th>
-                    <th>{{ __('cms.refunds.action') }}</th>
-                </tr>
-            </thead>
-        </table>
+    <div class="bg-white border border-gray-200 shadow-sm rounded-2xl">
+        <div class="px-6 py-5 border-b border-gray-200">
+            <h2 class="text-lg font-semibold text-gray-900">{{ __('cms.refunds.list') }}</h2>
+        </div>
+
+        <div class="px-6 py-6">
+            <div class="overflow-x-auto">
+                <table id="refunds-table" class="table w-full text-sm text-gray-600">
+                    <thead class="table-header">
+                        <tr>
+                            <th scope="col" class="table-header-cell">{{ __('cms.refunds.id') }}</th>
+                            <th scope="col" class="table-header-cell">{{ __('cms.refunds.payment') }}</th>
+                            <th scope="col" class="table-header-cell">{{ __('cms.refunds.amount') }}</th>
+                            <th scope="col" class="table-header-cell">{{ __('cms.refunds.status') }}</th>
+                            <th scope="col" class="table-header-cell">{{ __('cms.refunds.reason') }}</th>
+                            <th scope="col" class="table-header-cell">{{ __('cms.refunds.action') }}</th>
+                        </tr>
+                    </thead>
+                    <tbody class="table-body"></tbody>
+                </table>
+            </div>
+        </div>
     </div>
 </div>
 
-<!-- Delete Modal -->
-<div class="modal fade" id="deleteRefundModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <div class="modal-content">
-      <div class="modal-header">
-        <h5 class="modal-title">{{ __('cms.refunds.delete_confirm') }}</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-      </div>
-      <div class="modal-body">{{ __('cms.refunds.delete_message') }}</div>
-      <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ __('cms.refunds.cancel') }}</button>
-        <button type="button" class="btn btn-danger" id="confirmDeleteRefund">{{ __('cms.refunds.delete') }}</button>
-      </div>
+<div id="deleteRefundModal"
+     class="fixed inset-0 z-40 hidden"
+     role="dialog"
+     aria-modal="true"
+     aria-labelledby="deleteRefundModalTitle"
+     aria-hidden="true">
+    <div class="flex min-h-full items-center justify-center px-4 py-6">
+        <div class="absolute inset-0 bg-slate-900/50" data-refunds-modal-backdrop></div>
+
+        <div class="relative w-full max-w-md overflow-hidden rounded-2xl bg-white shadow-xl">
+            <div class="px-6 py-5 border-b border-gray-200">
+                <h2 id="deleteRefundModalTitle" class="text-lg font-semibold text-gray-900">
+                    {{ __('cms.refunds.delete_confirm') }}
+                </h2>
+            </div>
+
+            <div class="px-6 py-5">
+                <p class="text-sm text-gray-600">{{ __('cms.refunds.delete_message') }}</p>
+            </div>
+
+            <div class="flex items-center justify-end gap-3 px-6 py-4 border-t border-gray-200 bg-gray-50">
+                <button type="button" class="btn btn-outline" data-refunds-modal-close>
+                    {{ __('cms.refunds.cancel') }}
+                </button>
+                <button type="button" class="btn btn-danger" id="confirmDeleteRefund">
+                    {{ __('cms.refunds.delete') }}
+                </button>
+            </div>
+        </div>
     </div>
-  </div>
 </div>
 @endsection
 
@@ -46,11 +73,12 @@
 @endphp
 
 <script>
-$(document).ready(function() {
-    $('#refunds-table').DataTable({
+document.addEventListener('DOMContentLoaded', () => {
+    const tableElement = $('#refunds-table');
+    const dataTable = tableElement.DataTable({
         processing: true,
         serverSide: true,
-        ajax: "{{ route('admin.refunds.getData') }}",
+        ajax: @json(route('admin.refunds.getData')),
         language: @json($datatableLang),
         columns: [
             { data: 'id', name: 'id' },
@@ -58,63 +86,147 @@ $(document).ready(function() {
             { data: 'amount', name: 'amount' },
             { data: 'status', name: 'status' },
             { data: 'reason', name: 'reason' },
-            { data: 'action', orderable: false, searchable: false }
+            { data: 'action', orderable: false, searchable: false },
         ],
-        pageLength: 10
+        pageLength: 10,
+        responsive: true,
+        order: [[0, 'desc']],
     });
-});
 
-let refundToDeleteId = null;
+    tableElement.on('draw.dt', () => {
+        tableElement.find('tbody tr').each(function () {
+            this.classList.add('table-row');
+            $(this).children('td').each(function () {
+                this.classList.add('table-cell');
+            });
+        });
+    });
 
-$(document).on('click', '.btn-view-refund', function() {
-    const url = $(this).data('url');
-    if (url) {
-        window.location.href = url;
-    }
-});
+    let refundToDeleteId = null;
 
-$(document).on('click', '.btn-delete-refund', function() {
-    refundToDeleteId = $(this).data('id');
-    $('#deleteRefundModal').modal('show');
-});
+    const modal = document.getElementById('deleteRefundModal');
+    const modalBackdrop = modal?.querySelector('[data-refunds-modal-backdrop]');
+    const confirmButton = document.getElementById('confirmDeleteRefund');
+    const closeButtons = modal?.querySelectorAll('[data-refunds-modal-close]') ?? [];
 
-$('#confirmDeleteRefund').off('click').on('click', function() {
-    if (refundToDeleteId !== null) {
-        $.ajax({
-            url: '{{ route('admin.refunds.destroy', ':id') }}'.replace(':id', refundToDeleteId),
-            method: 'DELETE',
-            data: { _token: "{{ csrf_token() }}" },
-            success: function(response) {
-                if (response.success) {
-                    $('#refunds-table').DataTable().ajax.reload();
+    const openModal = () => {
+        if (!modal) {
+            return;
+        }
 
-                    toastr.error(response.message, "Deleted", {
+        modal.classList.remove('hidden');
+        modal.removeAttribute('aria-hidden');
+        document.body.classList.add('overflow-hidden');
+    };
+
+    const closeModal = () => {
+        if (!modal) {
+            return;
+        }
+
+        modal.classList.add('hidden');
+        modal.setAttribute('aria-hidden', 'true');
+        document.body.classList.remove('overflow-hidden');
+    };
+
+    document.addEventListener('click', (event) => {
+        const target = event.target;
+        if (!(target instanceof Element)) {
+            return;
+        }
+
+        const viewButton = target.closest('.btn-view-refund');
+        if (viewButton instanceof HTMLElement) {
+            const url = viewButton.dataset.url;
+            if (url) {
+                event.preventDefault();
+                window.location.href = url;
+            }
+        }
+
+        const deleteButton = target.closest('.btn-delete-refund');
+        if (deleteButton instanceof HTMLElement) {
+            const refundId = deleteButton.dataset.id;
+            if (refundId) {
+                event.preventDefault();
+                refundToDeleteId = refundId;
+                openModal();
+            }
+        }
+    });
+
+    confirmButton?.addEventListener('click', async () => {
+        if (!refundToDeleteId) {
+            return;
+        }
+
+        const deleteUrlTemplate = @json(route('admin.refunds.destroy', '__REFUND__'));
+        const deleteUrl = deleteUrlTemplate.replace('__REFUND__', refundToDeleteId);
+
+        try {
+            const { data } = await axios.delete(deleteUrl, {
+                data: { _token: @json(csrf_token()) },
+            });
+
+            if (data?.success) {
+                dataTable.ajax.reload(null, false);
+                toastr.success(
+                    data?.message ?? '{{ __('cms.refunds.delete') }}',
+                    '{{ __('cms.refunds.success') }}',
+                    {
                         closeButton: true,
                         progressBar: true,
-                        positionClass: "toast-top-right",
-                        timeOut: 5000
-                    });
-                    $('#deleteRefundModal').modal('hide');
-                } else {
-                    toastr.error(response.message || 'Error deleting refund!', "Error", {
+                        positionClass: 'toast-top-right',
+                        timeOut: 5000,
+                    }
+                );
+            } else {
+                toastr.error(
+                    data?.message ?? '{{ __('cms.refunds.delete_error') }}',
+                    '{{ __('cms.notifications.error') }}',
+                    {
                         closeButton: true,
                         progressBar: true,
-                        positionClass: "toast-top-right",
-                        timeOut: 5000
-                    });
-                }
-            },
-            error: function() {
-                toastr.error('Error deleting refund!', "Error", {
+                        positionClass: 'toast-top-right',
+                        timeOut: 5000,
+                    }
+                );
+            }
+        } catch (error) {
+            toastr.error(
+                '{{ __('cms.refunds.delete_error') }}',
+                '{{ __('cms.notifications.error') }}',
+                {
                     closeButton: true,
                     progressBar: true,
-                    positionClass: "toast-top-right",
-                    timeOut: 5000
-                });
-                $('#deleteRefundModal').modal('hide');
-            }
+                    positionClass: 'toast-top-right',
+                    timeOut: 5000,
+                }
+            );
+        } finally {
+            closeModal();
+            refundToDeleteId = null;
+        }
+    });
+
+    closeButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+            refundToDeleteId = null;
+            closeModal();
         });
-    }
+    });
+
+    modalBackdrop?.addEventListener('click', () => {
+        refundToDeleteId = null;
+        closeModal();
+    });
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && !modal?.classList.contains('hidden')) {
+            refundToDeleteId = null;
+            closeModal();
+        }
+    });
 });
 </script>
 @endsection

--- a/resources/views/admin/refunds/show.blade.php
+++ b/resources/views/admin/refunds/show.blade.php
@@ -1,54 +1,108 @@
 @extends('admin.layouts.admin')
 
 @section('content')
-    <div class="card mt-4">
-        <div class="card-header card-header-bg text-white">
-            <h6 class="mb-0">{{ __('cms.refunds.details_title') }}</h6>
+    @php
+        $status = strtolower($refund->status ?? 'pending');
+        $statusStyles = [
+            'completed' => 'bg-emerald-50 text-emerald-700 ring-emerald-500/20',
+            'pending' => 'bg-amber-50 text-amber-700 ring-amber-500/20',
+            'failed' => 'bg-rose-50 text-rose-700 ring-rose-500/20',
+        ];
+
+        $statusClass = $statusStyles[$status] ?? 'bg-gray-100 text-gray-700 ring-gray-500/10';
+        $payment = $refund->payment;
+        $paymentStatus = $payment?->status ?? __('cms.refunds.not_available');
+        $paymentAmount = $payment?->amount;
+        $paymentGateway = $payment?->gateway?->name;
+        $createdAt = optional($refund->created_at)->format('M d, Y h:i A');
+        $updatedAt = optional($refund->updated_at)->format('M d, Y h:i A');
+    @endphp
+
+    <div class="max-w-4xl mx-auto mt-4 space-y-6">
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+                <p class="text-sm font-medium text-primary-600 uppercase tracking-wide">{{ __('cms.refunds.title') }}</p>
+                <h1 class="text-3xl font-semibold text-gray-900">{{ __('cms.refunds.details_title') }}</h1>
+                <p class="mt-1 text-sm text-gray-500">{{ __('cms.refunds.manage') }}</p>
+            </div>
+            <span class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-sm font-medium ring-1 {{ $statusClass }}">
+                <span class="h-2 w-2 rounded-full bg-current"></span>
+                {{ ucfirst($refund->status) }}
+            </span>
         </div>
 
-        <div class="card-body">
-            <table class="table table-bordered">
-                <tr>
-                    <th>{{ __('cms.refunds.id') }}</th>
-                    <td>{{ $refund->id }}</td>
-                </tr>
-                <tr>
-                    <th>{{ __('cms.refunds.payment') }}</th>
-                    <td>
-                        @if ($refund->payment)
-                            {{ __('cms.refunds.payment') }} #{{ $refund->payment->id }}
-                            ({{ __('cms.refunds.amount') }}: {{ $refund->payment->amount }} –
-                            {{ __('cms.refunds.status') }}: {{ $refund->payment->status }})
-                        @else
-                            {{ __('cms.refunds.not_available') }}
-                        @endif
-                    </td>
-                </tr>
-                <tr>
-                    <th>{{ __('cms.refunds.amount') }}</th>
-                    <td>{{ $refund->amount }}</td>
-                </tr>
-                <tr>
-                    <th>{{ __('cms.refunds.status') }}</th>
-                    <td>{{ $refund->status }}</td>
-                </tr>
-                <tr>
-                    <th>{{ __('cms.refunds.reason') }}</th>
-                    <td>{{ $refund->reason ?? __('cms.refunds.not_available') }}</td>
-                </tr>
-                <tr>
-                    <th>{{ __('cms.refunds.created_at') }}</th>
-                    <td>{{ $refund->created_at }}</td>
-                </tr>
-                <tr>
-                    <th>{{ __('cms.refunds.updated_at') }}</th>
-                    <td>{{ $refund->updated_at }}</td>
-                </tr>
-            </table>
+        <div class="bg-white border border-gray-200 rounded-2xl shadow-sm">
+            <div class="px-6 py-5 border-b border-gray-200">
+                <h2 class="text-lg font-semibold text-gray-900">{{ __('cms.refunds.details_title') }}</h2>
+            </div>
 
-            <button type="button" class="btn btn-secondary mt-3" data-url="{{ route('admin.refunds.index') }}">
-                {{ __('cms.refunds.back') }}
-            </button>
+            <div class="px-6 py-6">
+                <dl class="grid grid-cols-1 gap-y-6 sm:grid-cols-2 sm:gap-x-6">
+                    <div>
+                        <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.id') }}</dt>
+                        <dd class="mt-1 text-base font-semibold text-gray-900">#{{ $refund->id }}</dd>
+                    </div>
+
+                    <div>
+                        <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.amount') }}</dt>
+                        <dd class="mt-1 text-base text-gray-900">{{ number_format((float) $refund->amount, 2) }}</dd>
+                    </div>
+
+                    <div class="sm:col-span-2">
+                        <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.payment') }}</dt>
+                        <dd class="mt-1 text-base text-gray-900">
+                            @if ($payment)
+                                <div class="flex flex-col gap-1">
+                                    <span class="font-semibold text-gray-900">{{ __('cms.refunds.payment') }} #{{ $payment->id }}</span>
+                                    <span class="text-sm text-gray-600">
+                                        {{ __('cms.payments.amount') }}: {{ number_format((float) $paymentAmount, 2) }}
+                                    </span>
+                                    <span class="text-sm text-gray-600">
+                                        {{ __('cms.payments.status') }}: {{ ucfirst($paymentStatus) }}
+                                    </span>
+                                    @if ($paymentGateway)
+                                        <span class="text-sm text-gray-600">
+                                            {{ __('cms.payments.gateway') }}: {{ $paymentGateway }}
+                                        </span>
+                                    @endif
+                                </div>
+                            @else
+                                <span class="text-sm text-gray-500">{{ __('cms.refunds.not_available') }}</span>
+                            @endif
+                        </dd>
+                    </div>
+
+                    <div class="sm:col-span-2">
+                        <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.reason') }}</dt>
+                        <dd class="mt-1 text-base text-gray-900 whitespace-pre-wrap">
+                            {{ $refund->reason ? $refund->reason : __('cms.refunds.not_available') }}
+                        </dd>
+                    </div>
+
+                    <div>
+                        <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.created_at') }}</dt>
+                        <dd class="mt-1 text-base text-gray-900">
+                            {{ $createdAt ?? __('cms.refunds.not_available') }}
+                        </dd>
+                    </div>
+
+                    <div>
+                        <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.updated_at') }}</dt>
+                        <dd class="mt-1 text-base text-gray-900">
+                            {{ $updatedAt ?? __('cms.refunds.not_available') }}
+                        </dd>
+                    </div>
+                </dl>
+            </div>
+
+            <div class="flex flex-col gap-3 border-t border-gray-200 bg-gray-50 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+                <p class="text-sm text-gray-500">{{ __('cms.refunds.manage') }}</p>
+                <div class="flex items-center gap-3">
+                    <button type="button" class="btn btn-outline" data-url="{{ route('admin.refunds.index') }}">
+                        {{ __('cms.refunds.back') }}
+                    </button>
+                </div>
+            </div>
         </div>
     </div>
 @endsection


### PR DESCRIPTION
## Summary
- redesign the refunds listing with the Tailwind admin card layout, a custom confirmation modal, and an axios-powered deletion flow
- refresh the refund detail page with responsive card styling, richer payment metadata, and formatted timestamps
- enhance the refunds DataTable backend to format amounts, badge statuses, and limit reason text for cleaner presentation

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68deea8970b883299ff3d2a048a5087d