### PR TITLE
Ensure image URLs and customer guard support

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -204,7 +204,8 @@ class PageController extends Controller
 
         return response()->json([
             'success' => true,
+            'status' => (bool) $page->status,
             'message' => 'Page status updated.',
-        ]);
+        ], 200);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -32,6 +32,10 @@ class AppServiceProvider extends ServiceProvider
             \App\Repositories\Admin\Category\CategoryRepository::class
         );
 
+        $this->app->singleton('auth.customer', function ($app) {
+            return $app['auth']->guard('customer');
+        });
+
         $this->app->singleton(ImageService::class, function ($app) {
             return new ImageService;
         });

--- a/app/Repositories/Admin/Category/CategoryRepository.php
+++ b/app/Repositories/Admin/Category/CategoryRepository.php
@@ -74,7 +74,7 @@ class CategoryRepository implements CategoryRepositoryInterface
         ]);
 
         foreach ($translations as $languageCode => $translation) {
-            $imagePath = null;
+            $imagePath = 'assets/images/placeholder-promo.svg';
 
             if (isset($translation['image']) && $translation['image'] instanceof \Illuminate\Http\UploadedFile) {
                 $imagePath = $translation['image']->store('categories', 'public');
@@ -104,7 +104,8 @@ class CategoryRepository implements CategoryRepositoryInterface
         ]);
 
         foreach ($translations as $languageCode => $translation) {
-            $imagePath = $category->translations()->where('language_code', $languageCode)->value('image_url');
+            $imagePath = $category->translations()->where('language_code', $languageCode)->value('image_url')
+                ?? 'assets/images/placeholder-promo.svg';
 
             if (isset($translation['image']) && $translation['image'] instanceof \Illuminate\Http\UploadedFile) {
                 $imagePath = $translation['image']->store('categories', 'public');

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Category>
+ */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(2, true);
+
+        return [
+            'slug' => Str::slug($name) . '-' . $this->faker->unique()->numberBetween(100, 999),
+            'status' => $this->faker->boolean(90),
+            'parent_category_id' => null,
+        ];
+    }
+}

--- a/database/factories/CategoryTranslationFactory.php
+++ b/database/factories/CategoryTranslationFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\CategoryTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CategoryTranslation>
+ */
+class CategoryTranslationFactory extends Factory
+{
+    protected $model = CategoryTranslation::class;
+
+    public function definition(): array
+    {
+        return [
+            'category_id' => Category::factory(),
+            'language_code' => $this->faker->unique()->lexify('??'),
+            'name' => $this->faker->words(2, true),
+            'description' => $this->faker->sentence(),
+            'image_url' => 'categories/' . $this->faker->unique()->uuid() . '.jpg',
+        ];
+    }
+}

--- a/tests/Feature/AdminPageBrowsingTest.php
+++ b/tests/Feature/AdminPageBrowsingTest.php
@@ -160,6 +160,7 @@ class AdminPageBrowsingTest extends TestCase
             'language_code' => 'en',
             'name' => 'Test Category',
             'description' => 'Category description',
+            'image_url' => 'categories/test-category.jpg',
         ]);
 
         $this->brand = Brand::create([
@@ -269,7 +270,7 @@ class AdminPageBrowsingTest extends TestCase
             'language_code' => 'en',
             'title' => 'Homepage Banner',
             'description' => 'Banner description',
-            'image_url' => null,
+            'image_url' => 'banners/homepage-banner.jpg',
             'type' => 'hero',
         ]);
 


### PR DESCRIPTION
## Summary
- register the `auth.customer` guard binding so it can be resolved in the service container during tests
- guarantee category translations always have an image URL by adding factories and a placeholder fallback
- expose the updated status flag in the admin page status endpoint response and adjust tests for the new image_url requirement

## Testing
- composer install *(fails: lock file conflicts with composer.json constraints)*

------
https://chatgpt.com/codex/tasks/task_e_68def20dcaf083299cf577714640b8e3