### PR TITLE
Add category factories and adjust page status response

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Language;
 use App\Models\Page;
 use App\Models\PageTranslation;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -191,7 +192,7 @@ class PageController extends Controller
         ]);
     }
 
-    public function updatePageStatus(Request $request)
+    public function updatePageStatus(Request $request): JsonResponse
     {
         $request->validate([
             'id' => 'required|exists:pages,id',
@@ -199,12 +200,13 @@ class PageController extends Controller
         ]);
 
         $page = Page::find($request->id);
-        $page->status = $request->status;
+        $page->status = (bool) $request->boolean('status');
         $page->save();
 
         return response()->json([
             'success' => true,
+            'status' => (bool) $page->status,
             'message' => 'Page status updated.',
-        ]);
+        ], JsonResponse::HTTP_OK);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -51,6 +51,10 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(MenuItemRepositoryInterface::class, MenuItemRepository::class);
 
         $this->app->bind(AttributeRepositoryInterface::class, AttributeRepository::class);
+
+        $this->app->bind('auth.customer', function ($app) {
+            return $app['auth']->guard('customer');
+        });
     }
 
     /**

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\CategoryTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Category>
+ */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(2, true);
+
+        return [
+            'slug' => Str::slug($name).'-'.$this->faker->unique()->numberBetween(1000, 9999),
+            'parent_category_id' => null,
+            'status' => true,
+        ];
+    }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (Category $category) {
+            $defaultLocale = config('app.locale', 'en');
+
+            CategoryTranslation::factory()->create([
+                'category_id' => $category->id,
+                'language_code' => $defaultLocale,
+            ]);
+        });
+    }
+}

--- a/database/factories/CategoryTranslationFactory.php
+++ b/database/factories/CategoryTranslationFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\CategoryTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<CategoryTranslation>
+ */
+class CategoryTranslationFactory extends Factory
+{
+    protected $model = CategoryTranslation::class;
+
+    public function definition(): array
+    {
+        return [
+            'category_id' => Category::factory(),
+            'language_code' => $this->faker->unique()->lexify('??'),
+            'name' => $this->faker->words(3, true),
+            'description' => $this->faker->sentence(),
+            'image_url' => 'categories/'.$this->faker->unique()->uuid.'.jpg',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add category and category translation factories that include the required `image_url` attribute
- bind the `auth.customer` guard into the container to restore the `auth.customer` middleware binding for tests
- update the page status AJAX endpoint to return an explicit HTTP 200 JSON payload with the new status flag

## Testing
- php artisan test --testsuite=Feature *(fails: missing vendor/autoload.php because composer.lock conflicts prevent installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68def22d5ebc8329b4fb9b79ad7fdfd4