### PR TITLE
Add factories for categories and restore customer guard binding

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -204,7 +204,8 @@ class PageController extends Controller
 
         return response()->json([
             'success' => true,
+            'status' => $page->status,
             'message' => 'Page status updated.',
-        ]);
+        ], 200);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -18,6 +18,7 @@ use App\Repositories\Admin\SocialMediaLink\SocialMediaLinkRepository;
 use App\Repositories\Admin\SocialMediaLink\SocialMediaLinkRepositoryInterface;
 use App\Services\Admin\ImageService;
 use App\Services\Admin\MenuService;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -51,6 +52,10 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(MenuItemRepositoryInterface::class, MenuItemRepository::class);
 
         $this->app->bind(AttributeRepositoryInterface::class, AttributeRepository::class);
+
+        $this->app->bind('auth.customer', function () {
+            return Auth::guard('customer');
+        });
     }
 
     /**

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\CategoryTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Category>
+ */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(2, true);
+
+        return [
+            'slug' => Str::slug($name).'-'.$this->faker->unique()->numberBetween(1000, 9999),
+            'parent_category_id' => null,
+            'status' => $this->faker->boolean(80),
+        ];
+    }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (Category $category) {
+            CategoryTranslation::factory()->create([
+                'category_id' => $category->id,
+                'language_code' => config('app.locale'),
+            ]);
+        });
+    }
+}

--- a/database/factories/CategoryTranslationFactory.php
+++ b/database/factories/CategoryTranslationFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\CategoryTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\CategoryTranslation>
+ */
+class CategoryTranslationFactory extends Factory
+{
+    protected $model = CategoryTranslation::class;
+
+    public function definition(): array
+    {
+        return [
+            'category_id' => Category::factory(),
+            'language_code' => 'en',
+            'name' => $this->faker->unique()->words(3, true),
+            'description' => $this->faker->sentence(),
+            'image_url' => 'categories/'.$this->faker->unique()->lexify('??????????').'.jpg',
+        ];
+    }
+}

--- a/database/factories/PageTranslationFactory.php
+++ b/database/factories/PageTranslationFactory.php
@@ -20,7 +20,7 @@ class PageTranslationFactory extends Factory
             'language_code' => $this->faker->unique()->lexify('??'),
             'title' => $this->faker->sentence(3),
             'content' => $this->faker->paragraph(),
-            'image_url' => null,
+            'image_url' => 'pages/'.$this->faker->unique()->lexify('??????????').'.jpg',
         ];
     }
 }


### PR DESCRIPTION
## Summary
- add dedicated factories for categories and their translations with default image paths
- update page translation factory to populate the required image_url column
- bind the customer authentication guard for tests and adjust the AJAX status response payload

## Testing
- Unable to run automated tests because `composer install` fails: lock file constraint mismatch


------
https://chatgpt.com/codex/tasks/task_e_68def20fc0988329a498a18778f9d8dc