### PR TITLE
Add category factories, guard setup, and page status response fixes

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -199,12 +199,13 @@ class PageController extends Controller
         ]);
 
         $page = Page::find($request->id);
-        $page->status = $request->status;
+        $page->status = $request->boolean('status');
         $page->save();
 
         return response()->json([
             'success' => true,
             'message' => 'Page status updated.',
-        ]);
+            'status' => (bool) $page->status,
+        ], 200);
     }
 }

--- a/app/Repositories/Admin/Category/CategoryRepository.php
+++ b/app/Repositories/Admin/Category/CategoryRepository.php
@@ -80,6 +80,8 @@ class CategoryRepository implements CategoryRepositoryInterface
                 $imagePath = $translation['image']->store('categories', 'public');
             }
 
+            $imagePath = $imagePath ?: $this->getDefaultImagePath();
+
             CategoryTranslation::create([
                 'category_id' => $category->id,
                 'language_code' => $languageCode,
@@ -109,6 +111,8 @@ class CategoryRepository implements CategoryRepositoryInterface
             if (isset($translation['image']) && $translation['image'] instanceof \Illuminate\Http\UploadedFile) {
                 $imagePath = $translation['image']->store('categories', 'public');
             }
+
+            $imagePath = $imagePath ?: $this->getDefaultImagePath();
 
             $category->translations()->updateOrCreate(
                 ['language_code' => $languageCode],
@@ -153,5 +157,10 @@ class CategoryRepository implements CategoryRepositoryInterface
         }
 
         return [];
+    }
+
+    protected function getDefaultImagePath(): string
+    {
+        return 'assets/images/placeholder-promo.svg';
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "guzzlehttp/guzzle": "^7.9",
-        "laravel/framework": "^12.0",
+        "laravel/framework": "^10.0",
         "laravel/sanctum": "^3.3",
         "laravel/tinker": "^2.9",
         "laravel/ui": "^4.6",

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<\App\Models\Category>
+ */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(2, true);
+
+        return [
+            'slug' => Str::slug($name).'-'.$this->faker->unique()->numberBetween(1000, 9999),
+            'parent_category_id' => null,
+            'status' => true,
+        ];
+    }
+}

--- a/database/factories/CategoryTranslationFactory.php
+++ b/database/factories/CategoryTranslationFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\CategoryTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\CategoryTranslation>
+ */
+class CategoryTranslationFactory extends Factory
+{
+    protected $model = CategoryTranslation::class;
+
+    public function definition(): array
+    {
+        return [
+            'category_id' => Category::factory(),
+            'language_code' => $this->faker->unique()->lexify('??'),
+            'name' => $this->faker->unique()->words(3, true),
+            'description' => $this->faker->sentence(),
+            'image_url' => 'categories/'.$this->faker->unique()->lexify('image-????').'.jpg',
+        ];
+    }
+}

--- a/tests/Feature/AdminPageBrowsingTest.php
+++ b/tests/Feature/AdminPageBrowsingTest.php
@@ -160,6 +160,7 @@ class AdminPageBrowsingTest extends TestCase
             'language_code' => 'en',
             'name' => 'Test Category',
             'description' => 'Category description',
+            'image_url' => 'categories/test-category.jpg',
         ]);
 
         $this->brand = Brand::create([

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,28 @@
 
 namespace Tests;
 
+use App\Http\Middleware\AuthenticateCustomer;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Facades\Config;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('auth.guards.customer', array_merge([
+            'driver' => 'session',
+            'provider' => 'customers',
+        ], Config::get('auth.guards.customer', [])));
+
+        Config::set('auth.providers.customers', array_merge([
+            'driver' => 'eloquent',
+            'model' => \App\Models\Customer::class,
+        ], Config::get('auth.providers.customers', [])));
+
+        $this->app['router']->aliasMiddleware('auth.customer', AuthenticateCustomer::class);
+    }
 }


### PR DESCRIPTION
## Summary
- add dedicated category factories that populate the required image_url field for new test data
- default missing category translation images to a placeholder path and return the toggled status from the AJAX endpoint
- ensure the customer guard and middleware are available in tests and align composer with the locked framework version

## Testing
- not run (composer install blocked by upstream 403 responses)


------
https://chatgpt.com/codex/tasks/task_e_68def2122c0c83298695c5ae936bb5c1