### PR TITLE
Add category image defaults and customer auth binding

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -199,12 +199,13 @@ class PageController extends Controller
         ]);
 
         $page = Page::find($request->id);
-        $page->status = $request->status;
+        $page->status = $request->boolean('status');
         $page->save();
 
         return response()->json([
             'success' => true,
             'message' => 'Page status updated.',
+            'status' => $page->status,
         ]);
     }
 }

--- a/app/Models/BannerTranslation.php
+++ b/app/Models/BannerTranslation.php
@@ -12,6 +12,15 @@ class BannerTranslation extends Model
     // Define the fillable attributes
     protected $fillable = ['banner_id', 'language_code', 'title', 'description', 'image_url', 'type'];
 
+    protected static function booted(): void
+    {
+        static::saving(function (self $translation) {
+            if (! $translation->image_url) {
+                $translation->image_url = 'assets/images/placeholder-banner.svg';
+            }
+        });
+    }
+
     // Relationship with Banner
     public function banner()
     {

--- a/app/Models/CategoryTranslation.php
+++ b/app/Models/CategoryTranslation.php
@@ -11,6 +11,15 @@ class CategoryTranslation extends Model
 
     protected $fillable = ['category_id', 'language_code', 'name', 'description', 'image_url'];
 
+    protected static function booted(): void
+    {
+        static::saving(function (self $translation) {
+            if (! $translation->image_url) {
+                $translation->image_url = 'assets/images/placeholder-promo.svg';
+            }
+        });
+    }
+
     public function category()
     {
         return $this->belongsTo(Category::class);

--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -11,6 +11,10 @@ class Page extends Model
 
     protected $fillable = ['slug', 'status'];
 
+    protected $casts = [
+        'status' => 'boolean',
+    ];
+
     public function translations()
     {
         return $this->hasMany(PageTranslation::class);

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -51,6 +51,10 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(MenuItemRepositoryInterface::class, MenuItemRepository::class);
 
         $this->app->bind(AttributeRepositoryInterface::class, AttributeRepository::class);
+
+        $this->app->bind('auth.customer', function ($app) {
+            return $app['auth']->guard('customer');
+        });
     }
 
     /**

--- a/app/Repositories/Admin/Category/CategoryRepository.php
+++ b/app/Repositories/Admin/Category/CategoryRepository.php
@@ -85,7 +85,7 @@ class CategoryRepository implements CategoryRepositoryInterface
                 'language_code' => $languageCode,
                 'name' => $translation['name'],
                 'description' => $translation['description'] ?? null,
-                'image_url' => $imagePath,
+                'image_url' => $imagePath ?? 'assets/images/placeholder-promo.svg',
             ]);
         }
 
@@ -115,7 +115,7 @@ class CategoryRepository implements CategoryRepositoryInterface
                 [
                     'name' => $translation['name'],
                     'description' => $translation['description'] ?? null,
-                    'image_url' => $imagePath,
+                    'image_url' => $imagePath ?? 'assets/images/placeholder-promo.svg',
                 ]
             );
         }

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\CategoryTranslation;
+use App\Models\Language;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Category>
+ */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    public function definition(): array
+    {
+        return [
+            'slug' => Str::slug($this->faker->unique()->words(2, true)).'-'.$this->faker->numberBetween(100, 999),
+            'parent_category_id' => null,
+            'status' => true,
+        ];
+    }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (Category $category) {
+            $languageCodes = Language::where('active', true)->pluck('code');
+
+            if ($languageCodes->isEmpty()) {
+                $languageCodes = collect([config('app.locale', 'en')]);
+            }
+
+            $translations = $languageCodes->map(fn ($code) => CategoryTranslation::factory()->make([
+                'category_id' => $category->id,
+                'language_code' => $code,
+            ]));
+
+            $category->translations()->saveMany($translations);
+        });
+    }
+}

--- a/database/factories/CategoryTranslationFactory.php
+++ b/database/factories/CategoryTranslationFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\CategoryTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\CategoryTranslation>
+ */
+class CategoryTranslationFactory extends Factory
+{
+    protected $model = CategoryTranslation::class;
+
+    public function definition(): array
+    {
+        return [
+            'category_id' => Category::factory(),
+            'language_code' => config('app.locale', 'en'),
+            'name' => $this->faker->unique()->words(2, true),
+            'description' => $this->faker->sentence(),
+            'image_url' => 'categories/'.$this->faker->unique()->uuid.'.jpg',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add dedicated category factories with image defaults for new translation column
- ensure category and banner translations always persist a placeholder image when none is supplied
- bind the customer guard in the service container and normalize the page status ajax response payload

## Testing
- php artisan test *(fails: vendor dependencies not installed because composer.json/lock mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68def214133083298070df20b868aab5