### PR TITLE
Fix factories and page status response

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -193,18 +193,19 @@ class PageController extends Controller
 
     public function updatePageStatus(Request $request)
     {
-        $request->validate([
+        $data = $request->validate([
             'id' => 'required|exists:pages,id',
             'status' => 'required|boolean',
         ]);
 
-        $page = Page::find($request->id);
-        $page->status = $request->status;
+        $page = Page::findOrFail($data['id']);
+        $page->status = (bool) $data['status'];
         $page->save();
 
         return response()->json([
             'success' => true,
-            'message' => 'Page status updated.',
+            'message' => __('cms.pages.status_updated'),
+            'status' => $page->status,
         ]);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -18,6 +18,7 @@ use App\Repositories\Admin\SocialMediaLink\SocialMediaLinkRepository;
 use App\Repositories\Admin\SocialMediaLink\SocialMediaLinkRepositoryInterface;
 use App\Services\Admin\ImageService;
 use App\Services\Admin\MenuService;
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -51,6 +52,10 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(MenuItemRepositoryInterface::class, MenuItemRepository::class);
 
         $this->app->bind(AttributeRepositoryInterface::class, AttributeRepository::class);
+
+        $this->app->bind('auth.customer', function ($app) {
+            return $app->make(AuthFactory::class)->guard('customer');
+        });
     }
 
     /**

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\CategoryTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Category>
+ */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(2, true);
+
+        return [
+            'slug' => Str::slug($name).'-'.$this->faker->unique()->numberBetween(100, 9999),
+            'status' => true,
+            'parent_category_id' => null,
+        ];
+    }
+
+    public function withTranslation(?string $languageCode = null): static
+    {
+        return $this->afterCreating(function (Category $category) use ($languageCode) {
+            CategoryTranslation::factory()->create([
+                'category_id' => $category->id,
+                'language_code' => $languageCode ?? config('app.locale', 'en'),
+            ]);
+        });
+    }
+}

--- a/database/factories/CategoryTranslationFactory.php
+++ b/database/factories/CategoryTranslationFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\CategoryTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\CategoryTranslation>
+ */
+class CategoryTranslationFactory extends Factory
+{
+    protected $model = CategoryTranslation::class;
+
+    public function definition(): array
+    {
+        return [
+            'category_id' => Category::factory(),
+            'language_code' => $this->faker->unique()->lexify('??'),
+            'name' => $this->faker->words(3, true),
+            'description' => $this->faker->sentence(),
+            'image_url' => 'categories/'.$this->faker->unique()->lexify('image_????').'.jpg',
+        ];
+    }
+}

--- a/database/factories/PageTranslationFactory.php
+++ b/database/factories/PageTranslationFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Models\Page;
 use App\Models\PageTranslation;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\PageTranslation>
@@ -20,7 +21,7 @@ class PageTranslationFactory extends Factory
             'language_code' => $this->faker->unique()->lexify('??'),
             'title' => $this->faker->sentence(3),
             'content' => $this->faker->paragraph(),
-            'image_url' => null,
+            'image_url' => 'pages/'.Str::slug($this->faker->unique()->sentence(2)).'.jpg',
         ];
     }
 }

--- a/resources/lang/en/cms.php
+++ b/resources/lang/en/cms.php
@@ -340,6 +340,7 @@ return [
         // Toastr messages
         'toastr_success' => 'Success',
         'toastr_error' => 'Error deleting page',
+        'status_updated' => 'Page status updated successfully!',
     ],
 
     'customers' => [

--- a/tests/Feature/AdminPageBrowsingTest.php
+++ b/tests/Feature/AdminPageBrowsingTest.php
@@ -160,6 +160,7 @@ class AdminPageBrowsingTest extends TestCase
             'language_code' => 'en',
             'name' => 'Test Category',
             'description' => 'Category description',
+            'image_url' => 'categories/test-category.jpg',
         ]);
 
         $this->brand = Brand::create([
@@ -269,7 +270,7 @@ class AdminPageBrowsingTest extends TestCase
             'language_code' => 'en',
             'title' => 'Homepage Banner',
             'description' => 'Banner description',
-            'image_url' => null,
+            'image_url' => 'banner_images/homepage-banner.jpg',
             'type' => 'hero',
         ]);
 
@@ -368,7 +369,7 @@ class AdminPageBrowsingTest extends TestCase
             'language_code' => 'en',
             'title' => 'About us',
             'content' => 'About page content',
-            'image_url' => null,
+            'image_url' => 'pages/about-us.jpg',
         ]);
 
         SiteSetting::create([


### PR DESCRIPTION
## Summary
- add dedicated factories for categories and translations with default image paths
- ensure page-related factories, language strings, and feature tests supply the required image_url values
- bind the auth.customer guard for tests and return a localized status payload from the page status endpoint

## Testing
- composer install *(fails: lock file constraint conflict between composer.json and composer.lock)*

------
https://chatgpt.com/codex/tasks/task_e_68def215be308329a29f4659e0d8a35e