### PR TITLE
Ensure factories use image_url and register customer guard

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -199,12 +199,13 @@ class PageController extends Controller
         ]);
 
         $page = Page::find($request->id);
-        $page->status = $request->status;
+        $page->status = $request->boolean('status');
         $page->save();
 
         return response()->json([
             'success' => true,
-            'message' => 'Page status updated.',
-        ]);
+            'message' => 'Page status updated successfully.',
+            'status' => (bool) $page->status,
+        ], 200);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -18,6 +18,7 @@ use App\Repositories\Admin\SocialMediaLink\SocialMediaLinkRepository;
 use App\Repositories\Admin\SocialMediaLink\SocialMediaLinkRepositoryInterface;
 use App\Services\Admin\ImageService;
 use App\Services\Admin\MenuService;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -51,6 +52,10 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(MenuItemRepositoryInterface::class, MenuItemRepository::class);
 
         $this->app->bind(AttributeRepositoryInterface::class, AttributeRepository::class);
+
+        $this->app->singleton('auth.customer', function () {
+            return Auth::guard('customer');
+        });
     }
 
     /**

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Category>
+ */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(2, true);
+
+        return [
+            'slug' => Str::slug($name.'-'.$this->faker->unique()->numberBetween(1, 9999)),
+            'parent_category_id' => null,
+            'status' => true,
+        ];
+    }
+}

--- a/database/factories/PageTranslationFactory.php
+++ b/database/factories/PageTranslationFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Models\Page;
 use App\Models\PageTranslation;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\PageTranslation>
@@ -20,7 +21,7 @@ class PageTranslationFactory extends Factory
             'language_code' => $this->faker->unique()->lexify('??'),
             'title' => $this->faker->sentence(3),
             'content' => $this->faker->paragraph(),
-            'image_url' => null,
+            'image_url' => 'pages/'.Str::uuid().'.jpg',
         ];
     }
 }


### PR DESCRIPTION
## Summary
- provide factories with required image_url data and add a Category factory
- register the auth.customer guard binding so it can be resolved during tests
- adjust the page status AJAX response payload to return the updated status information

## Testing
- php artisan test --filter=AdminPageManagementTest *(fails: vendor directory missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68def2182c3c83298e07e29b508550df