### PR TITLE
Ensure image URL support and restore customer guard for tests

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -205,6 +205,7 @@ class PageController extends Controller
         return response()->json([
             'success' => true,
             'message' => 'Page status updated.',
-        ]);
+            'status' => (bool) $page->status,
+        ], 200);
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,7 @@
 <?php
 
+use App\Http\Middleware\AuthenticateCustomer;
+use App\Http\Middleware\AuthenticateVendor;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -16,7 +18,10 @@ return Application::configure(basePath: dirname(__DIR__))
         },
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'auth.customer' => AuthenticateCustomer::class,
+            'auth.vendor' => AuthenticateVendor::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<\App\Models\Category>
+ */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    public function definition(): array
+    {
+        return [
+            'slug' => Str::slug($this->faker->unique()->words(2, true)).'-'.$this->faker->unique()->numberBetween(100, 999),
+            'parent_category_id' => null,
+            'status' => true,
+        ];
+    }
+}

--- a/database/factories/PageTranslationFactory.php
+++ b/database/factories/PageTranslationFactory.php
@@ -20,7 +20,7 @@ class PageTranslationFactory extends Factory
             'language_code' => $this->faker->unique()->lexify('??'),
             'title' => $this->faker->sentence(3),
             'content' => $this->faker->paragraph(),
-            'image_url' => null,
+            'image_url' => 'pages/'.$this->faker->uuid().'.jpg',
         ];
     }
 }

--- a/tests/Feature/AdminPageBrowsingTest.php
+++ b/tests/Feature/AdminPageBrowsingTest.php
@@ -269,7 +269,7 @@ class AdminPageBrowsingTest extends TestCase
             'language_code' => 'en',
             'title' => 'Homepage Banner',
             'description' => 'Banner description',
-            'image_url' => null,
+            'image_url' => 'banners/test-banner.jpg',
             'type' => 'hero',
         ]);
 
@@ -368,7 +368,7 @@ class AdminPageBrowsingTest extends TestCase
             'language_code' => 'en',
             'title' => 'About us',
             'content' => 'About page content',
-            'image_url' => null,
+            'image_url' => 'pages/about-us.jpg',
         ]);
 
         SiteSetting::create([

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,25 @@
 
 namespace Tests;
 
+use App\Models\Customer;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config()->set('auth.providers.customers', config('auth.providers.customers', [
+            'driver' => 'eloquent',
+            'model' => Customer::class,
+        ]));
+
+        config()->set('auth.guards.customer', config('auth.guards.customer', [
+            'driver' => 'session',
+            'provider' => 'customers',
+        ]));
+    }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `Database\Factories\CategoryFactory` and ensure page translations seed an image URL
- register the `auth.customer` guard configuration for the test suite and expose customer/vendor middleware aliases in the bootstrap middleware map
- return the updated status flag in the AJAX page-status response and update test fixtures to use non-null banner/page images

## Testing
- not run (composer install fails: lock file requires laravel/framework v10.49.1 which does not satisfy ^12.0)


------
https://chatgpt.com/codex/tasks/task_e_68def21d11508329a1c21ea5ccf0eb85