### PR TITLE
Add category factory and adjust page status response

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -9,6 +9,7 @@ use App\Models\PageTranslation;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
 use Yajra\DataTables\Facades\DataTables;
 
 class PageController extends Controller
@@ -205,6 +206,9 @@ class PageController extends Controller
         return response()->json([
             'success' => true,
             'message' => 'Page status updated.',
-        ]);
+            'data' => [
+                'status' => (bool) $page->status,
+            ],
+        ], Response::HTTP_OK);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -18,6 +18,7 @@ use App\Repositories\Admin\SocialMediaLink\SocialMediaLinkRepository;
 use App\Repositories\Admin\SocialMediaLink\SocialMediaLinkRepositoryInterface;
 use App\Services\Admin\ImageService;
 use App\Services\Admin\MenuService;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -51,6 +52,10 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(MenuItemRepositoryInterface::class, MenuItemRepository::class);
 
         $this->app->bind(AttributeRepositoryInterface::class, AttributeRepository::class);
+
+        $this->app->singleton('auth.customer', function ($app) {
+            return Auth::guard('customer');
+        });
     }
 
     /**

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\Language;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Category>
+ */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    public function definition(): array
+    {
+        return [
+            'slug' => Str::slug($this->faker->unique()->words(2, true)),
+            'parent_category_id' => null,
+            'status' => true,
+        ];
+    }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (Category $category): void {
+            $languages = Language::query()
+                ->where('active', true)
+                ->pluck('code');
+
+            if ($languages->isEmpty()) {
+                $languages = collect([config('app.locale', 'en')]);
+            }
+
+            foreach ($languages as $languageCode) {
+                $category->translations()->create([
+                    'language_code' => $languageCode,
+                    'name' => fake()->words(2, true),
+                    'description' => fake()->sentence(),
+                    'image_url' => 'categories/'.Str::uuid().'.jpg',
+                ]);
+            }
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated `CategoryFactory` that generates translated records with image URLs so the new column is populated in tests and seed data
- register the `auth.customer` guard binding to make the customer guard resolvable during automated tests
- return a richer JSON payload (including the updated status) and an explicit 200 code from the page status toggle endpoint

## Testing
- composer install --no-interaction *(fails: lock file requires laravel/framework v10.49.1 but composer.json requests ^12.0)*

------
https://chatgpt.com/codex/tasks/task_e_68def220ae58832995304579cf650e79