### PR TITLE
Fix factories, guards, and page status response for image URL support

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -198,13 +198,19 @@ class PageController extends Controller
             'status' => 'required|boolean',
         ]);
 
-        $page = Page::find($request->id);
-        $page->status = $request->status;
+        $page = Page::findOrFail($request->id);
+        $page->status = (bool) $request->boolean('status');
         $page->save();
+
+        $page->refresh();
 
         return response()->json([
             'success' => true,
-            'message' => 'Page status updated.',
+            'message' => 'Page status updated successfully.',
+            'data' => [
+                'id' => $page->id,
+                'status' => (bool) $page->status,
+            ],
         ]);
     }
 }

--- a/app/Models/BannerTranslation.php
+++ b/app/Models/BannerTranslation.php
@@ -12,6 +12,15 @@ class BannerTranslation extends Model
     // Define the fillable attributes
     protected $fillable = ['banner_id', 'language_code', 'title', 'description', 'image_url', 'type'];
 
+    protected static function booted(): void
+    {
+        static::saving(function (self $translation): void {
+            if (empty($translation->image_url)) {
+                $translation->image_url = 'assets/images/placeholder-banner.svg';
+            }
+        });
+    }
+
     // Relationship with Banner
     public function banner()
     {

--- a/app/Models/CategoryTranslation.php
+++ b/app/Models/CategoryTranslation.php
@@ -11,6 +11,15 @@ class CategoryTranslation extends Model
 
     protected $fillable = ['category_id', 'language_code', 'name', 'description', 'image_url'];
 
+    protected static function booted(): void
+    {
+        static::saving(function (self $translation): void {
+            if (empty($translation->image_url)) {
+                $translation->image_url = 'assets/images/placeholder-promo.svg';
+            }
+        });
+    }
+
     public function category()
     {
         return $this->belongsTo(Category::class);

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\Language;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Category>
+ */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(2, true);
+
+        return [
+            'slug' => Str::slug($name) . '-' . $this->faker->unique()->numberBetween(1000, 9999),
+            'parent_category_id' => null,
+            'status' => $this->faker->boolean(90),
+        ];
+    }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (Category $category): void {
+            $languages = Language::query()
+                ->where('active', 1)
+                ->pluck('code')
+                ->filter()
+                ->all();
+
+            if (empty($languages)) {
+                $languages = [config('app.locale', 'en')];
+            }
+
+            foreach ($languages as $languageCode) {
+                $category->translations()->create([
+                    'language_code' => $languageCode,
+                    'name' => ucfirst(fake()->words(2, true)),
+                    'description' => fake()->sentence(),
+                    'image_url' => 'assets/images/placeholder-promo.svg',
+                ]);
+            }
+        });
+    }
+}

--- a/database/factories/PageTranslationFactory.php
+++ b/database/factories/PageTranslationFactory.php
@@ -20,7 +20,7 @@ class PageTranslationFactory extends Factory
             'language_code' => $this->faker->unique()->lexify('??'),
             'title' => $this->faker->sentence(3),
             'content' => $this->faker->paragraph(),
-            'image_url' => null,
+            'image_url' => 'pages/'.$this->faker->unique()->lexify('image_????').'.jpg',
         ];
     }
 }

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -2,6 +2,8 @@
 
 namespace Tests;
 
+use App\Http\Middleware\AuthenticateCustomer;
+use App\Models\Customer;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Foundation\Application;
 
@@ -15,6 +17,18 @@ trait CreatesApplication
         $app = require __DIR__.'/../bootstrap/app.php';
 
         $app->make(Kernel::class)->bootstrap();
+
+        $app->make('router')->aliasMiddleware('auth.customer', AuthenticateCustomer::class);
+
+        config()->set('auth.guards.customer', [
+            'driver' => 'session',
+            'provider' => 'customers',
+        ]);
+
+        config()->set('auth.providers.customers', [
+            'driver' => 'eloquent',
+            'model' => Customer::class,
+        ]);
 
         return $app;
     }


### PR DESCRIPTION
## Summary
- add a dedicated Category factory that seeds translations with the new image_url column
- update page translation factories and translation models to default image URLs when none are provided
- ensure the auth.customer middleware alias and guard configuration are registered for tests and enrich the page status AJAX response

## Testing
- Not run (composer install currently blocked by lockfile/framework version mismatch)


------
https://chatgpt.com/codex/tasks/task_e_68def225bcd083298676d6333645ed56