### PR TITLE
Add category factory and adjust page status response

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -9,6 +9,7 @@ use App\Models\PageTranslation;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
 use Yajra\DataTables\Facades\DataTables;
 
 class PageController extends Controller
@@ -198,13 +199,14 @@ class PageController extends Controller
             'status' => 'required|boolean',
         ]);
 
-        $page = Page::find($request->id);
-        $page->status = $request->status;
+        $page = Page::findOrFail($request->id);
+        $page->status = $request->boolean('status');
         $page->save();
 
         return response()->json([
             'success' => true,
+            'status' => (bool) $page->status,
             'message' => 'Page status updated.',
-        ]);
+        ], Response::HTTP_OK);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -51,6 +51,10 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(MenuItemRepositoryInterface::class, MenuItemRepository::class);
 
         $this->app->bind(AttributeRepositoryInterface::class, AttributeRepository::class);
+
+        $this->app->singleton('auth.customer', function ($app) {
+            return $app['auth']->guard('customer');
+        });
     }
 
     /**

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\Language;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Category>
+ */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(2, true);
+
+        return [
+            'slug' => Str::slug($name.'-'.$this->faker->unique()->numerify('###')),
+            'status' => true,
+            'parent_category_id' => null,
+        ];
+    }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (Category $category): void {
+            $faker = fake();
+
+            $languageCodes = Language::query()
+                ->where('active', true)
+                ->pluck('code')
+                ->all();
+
+            if (empty($languageCodes)) {
+                $languageCodes = [config('app.locale') ?? 'en'];
+            }
+
+            foreach ($languageCodes as $code) {
+                $category->translations()->create([
+                    'language_code' => $code,
+                    'name' => $faker->words(2, true),
+                    'description' => $faker->sentence(),
+                    'image_url' => 'categories/'.$faker->unique()->lexify('image-????').'.jpg',
+                ]);
+            }
+        });
+    }
+}

--- a/database/factories/PageTranslationFactory.php
+++ b/database/factories/PageTranslationFactory.php
@@ -20,7 +20,7 @@ class PageTranslationFactory extends Factory
             'language_code' => $this->faker->unique()->lexify('??'),
             'title' => $this->faker->sentence(3),
             'content' => $this->faker->paragraph(),
-            'image_url' => null,
+            'image_url' => 'pages/'.$this->faker->unique()->lexify('image-????').'.jpg',
         ];
     }
 }


### PR DESCRIPTION
## Summary
- add a dedicated `CategoryFactory` that builds translated records with image URLs for active languages
- ensure the `PageTranslationFactory` seeds the required `image_url`
- register the `auth.customer` guard binding for tests and harden the admin page status JSON response

## Testing
- not run (dependencies unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68def22f559c8329a8a72a944088984a