### PR TITLE
Add category factories and fix page status response

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -198,13 +198,17 @@ class PageController extends Controller
             'status' => 'required|boolean',
         ]);
 
-        $page = Page::find($request->id);
-        $page->status = $request->status;
+        $page = Page::findOrFail($request->id);
+        $page->status = $request->boolean('status');
         $page->save();
 
         return response()->json([
             'success' => true,
             'message' => 'Page status updated.',
+            'data' => [
+                'id' => $page->id,
+                'status' => (bool) $page->status,
+            ],
         ]);
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\AuthenticateCustomer;
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
@@ -16,7 +17,9 @@ return Application::configure(basePath: dirname(__DIR__))
         },
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'auth.customer' => AuthenticateCustomer::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\CategoryTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Category>
+ */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    public function definition(): array
+    {
+        $slugBase = Str::slug($this->faker->unique()->words(2, true));
+
+        return [
+            'slug' => $slugBase,
+            'parent_category_id' => null,
+            'status' => $this->faker->boolean(80),
+        ];
+    }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (Category $category) {
+            $defaultLocale = config('app.locale');
+
+            CategoryTranslation::factory()
+                ->for($category)
+                ->forLanguage($defaultLocale)
+                ->create();
+        });
+    }
+}

--- a/database/factories/CategoryTranslationFactory.php
+++ b/database/factories/CategoryTranslationFactory.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\CategoryTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<CategoryTranslation>
+ */
+class CategoryTranslationFactory extends Factory
+{
+    protected $model = CategoryTranslation::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(2, true);
+
+        return [
+            'category_id' => Category::factory(),
+            'language_code' => 'en',
+            'name' => $name,
+            'description' => $this->faker->sentence(),
+            'image_url' => 'categories/'.Str::slug($name.'-'.$this->faker->unique()->numberBetween(1, 9999)).'.jpg',
+        ];
+    }
+
+    /**
+     * Indicate that the translation should be created for a specific language.
+     */
+    public function forLanguage(string $languageCode): static
+    {
+        return $this->state(fn () => [
+            'language_code' => $languageCode,
+        ]);
+    }
+}

--- a/database/factories/PageTranslationFactory.php
+++ b/database/factories/PageTranslationFactory.php
@@ -5,6 +5,7 @@ namespace Database\Factories;
 use App\Models\Page;
 use App\Models\PageTranslation;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 
 /**
  * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\PageTranslation>
@@ -15,12 +16,14 @@ class PageTranslationFactory extends Factory
 
     public function definition(): array
     {
+        $title = $this->faker->sentence(3);
+
         return [
             'page_id' => Page::factory(),
             'language_code' => $this->faker->unique()->lexify('??'),
-            'title' => $this->faker->sentence(3),
+            'title' => $title,
             'content' => $this->faker->paragraph(),
-            'image_url' => null,
+            'image_url' => 'pages/'.Str::slug($title.'-'.$this->faker->unique()->numberBetween(1, 9999)).'.jpg',
         ];
     }
 }


### PR DESCRIPTION
## Summary
- add factories for categories and category translations that include the required image_url column
- register the auth.customer middleware alias so the customer guard can be used in tests
- ensure seeded/factory page translations provide an image_url and return structured data from the page status AJAX endpoint

## Testing
- php artisan test *(fails: composer install cannot run because composer.lock targets Laravel v10 while composer.json requires ^12.0)*

------
https://chatgpt.com/codex/tasks/task_e_68def231b8fc8329b0c0781c126295b5