### PR TITLE
Ensure factories handle image_url and fix page status API

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Language;
 use App\Models\Page;
 use App\Models\PageTranslation;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
@@ -191,20 +192,21 @@ class PageController extends Controller
         ]);
     }
 
-    public function updatePageStatus(Request $request)
+    public function updatePageStatus(Request $request): JsonResponse
     {
         $request->validate([
             'id' => 'required|exists:pages,id',
             'status' => 'required|boolean',
         ]);
 
-        $page = Page::find($request->id);
-        $page->status = $request->status;
+        $page = Page::findOrFail($request->id);
+        $page->status = (bool) $request->status;
         $page->save();
 
         return response()->json([
             'success' => true,
             'message' => 'Page status updated.',
+            'status' => (bool) $page->status,
         ]);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -51,6 +51,10 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(MenuItemRepositoryInterface::class, MenuItemRepository::class);
 
         $this->app->bind(AttributeRepositoryInterface::class, AttributeRepository::class);
+
+        $this->app->bind('auth.customer', function ($app) {
+            return $app['auth']->guard('customer');
+        });
     }
 
     /**

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Category>
+ */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->words(2, true);
+
+        return [
+            'slug' => Str::slug($name).'-'.$this->faker->unique()->numberBetween(1000, 9999),
+            'parent_category_id' => null,
+            'status' => true,
+        ];
+    }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (Category $category): void {
+            $category->translations()->create([
+                'language_code' => config('app.locale', 'en'),
+                'name' => $this->faker->words(2, true),
+                'description' => $this->faker->sentence(),
+                'image_url' => 'categories/'.$this->faker->unique()->uuid().'.jpg',
+            ]);
+        });
+    }
+}

--- a/database/factories/PageTranslationFactory.php
+++ b/database/factories/PageTranslationFactory.php
@@ -15,12 +15,14 @@ class PageTranslationFactory extends Factory
 
     public function definition(): array
     {
+        $imageName = $this->faker->unique()->uuid().'.jpg';
+
         return [
             'page_id' => Page::factory(),
             'language_code' => $this->faker->unique()->lexify('??'),
             'title' => $this->faker->sentence(3),
             'content' => $this->faker->paragraph(),
-            'image_url' => null,
+            'image_url' => 'pages/'.$imageName,
         ];
     }
 }


### PR DESCRIPTION
## Summary
- add a category factory that seeds translation data with the required image_url
- default the page translation factory to provide an image_url path
- bind the auth.customer guard in the service container and include the current status in the page status AJAX response

## Testing
- php artisan test *(fails: dependencies not installed because composer.json and composer.lock disagree)*

------
https://chatgpt.com/codex/tasks/task_e_68def232beb083298ee579ae58b2837f