### PR TITLE
Add category factories, defaults, and restore customer guard binding

### DIFF
--- a/app/Http/Controllers/Admin/PageController.php
+++ b/app/Http/Controllers/Admin/PageController.php
@@ -198,12 +198,13 @@ class PageController extends Controller
             'status' => 'required|boolean',
         ]);
 
-        $page = Page::find($request->id);
-        $page->status = $request->status;
+        $page = Page::findOrFail($request->id);
+        $page->status = (bool) $request->boolean('status');
         $page->save();
 
         return response()->json([
             'success' => true,
+            'status' => $page->status,
             'message' => 'Page status updated.',
         ]);
     }

--- a/app/Models/CategoryTranslation.php
+++ b/app/Models/CategoryTranslation.php
@@ -9,7 +9,16 @@ class CategoryTranslation extends Model
 {
     use HasFactory;
 
+    public const DEFAULT_IMAGE_PATH = 'assets/images/placeholder-promo.svg';
+
     protected $fillable = ['category_id', 'language_code', 'name', 'description', 'image_url'];
+
+    protected static function booted(): void
+    {
+        static::saving(function (CategoryTranslation $translation) {
+            $translation->image_url = $translation->image_url ?? self::DEFAULT_IMAGE_PATH;
+        });
+    }
 
     public function category()
     {

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -18,6 +18,7 @@ use App\Repositories\Admin\SocialMediaLink\SocialMediaLinkRepository;
 use App\Repositories\Admin\SocialMediaLink\SocialMediaLinkRepositoryInterface;
 use App\Services\Admin\ImageService;
 use App\Services\Admin\MenuService;
+use Illuminate\Contracts\Auth\StatefulGuard;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -31,6 +32,10 @@ class AppServiceProvider extends ServiceProvider
             \App\Repositories\Admin\Category\CategoryRepositoryInterface::class,
             \App\Repositories\Admin\Category\CategoryRepository::class
         );
+
+        $this->app->singleton('auth.customer', function ($app): StatefulGuard {
+            return $app['auth']->guard('customer');
+        });
 
         $this->app->singleton(ImageService::class, function ($app) {
             return new ImageService;

--- a/database/factories/CategoryFactory.php
+++ b/database/factories/CategoryFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\CategoryTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Category>
+ */
+class CategoryFactory extends Factory
+{
+    protected $model = Category::class;
+
+    public function definition(): array
+    {
+        return [
+            'slug' => Str::slug($this->faker->unique()->words(2, true)),
+            'parent_category_id' => null,
+            'status' => $this->faker->boolean(90),
+        ];
+    }
+
+    public function configure(): static
+    {
+        return $this->afterCreating(function (Category $category) {
+            $languageCode = config('app.locale', 'en');
+
+            if ($category->translations()->where('language_code', $languageCode)->doesntExist()) {
+                CategoryTranslation::factory()->for($category)->create([
+                    'language_code' => $languageCode,
+                ]);
+            }
+        });
+    }
+}

--- a/database/factories/CategoryTranslationFactory.php
+++ b/database/factories/CategoryTranslationFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Category;
+use App\Models\CategoryTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\CategoryTranslation>
+ */
+class CategoryTranslationFactory extends Factory
+{
+    protected $model = CategoryTranslation::class;
+
+    public function definition(): array
+    {
+        return [
+            'category_id' => Category::factory(),
+            'language_code' => $this->faker->lexify('??'),
+            'name' => $this->faker->words(3, true),
+            'description' => $this->faker->sentence(12),
+            'image_url' => 'categories/'.$this->faker->unique()->lexify('image-????????').'.jpg',
+        ];
+    }
+}

--- a/database/factories/PageTranslationFactory.php
+++ b/database/factories/PageTranslationFactory.php
@@ -20,7 +20,7 @@ class PageTranslationFactory extends Factory
             'language_code' => $this->faker->unique()->lexify('??'),
             'title' => $this->faker->sentence(3),
             'content' => $this->faker->paragraph(),
-            'image_url' => null,
+            'image_url' => 'pages/'.$this->faker->unique()->lexify('image-????????').'.jpg',
         ];
     }
 }

--- a/tests/Feature/AdminPageBrowsingTest.php
+++ b/tests/Feature/AdminPageBrowsingTest.php
@@ -160,6 +160,7 @@ class AdminPageBrowsingTest extends TestCase
             'language_code' => 'en',
             'name' => 'Test Category',
             'description' => 'Category description',
+            'image_url' => 'assets/images/placeholder-promo.svg',
         ]);
 
         $this->brand = Brand::create([


### PR DESCRIPTION
## Summary
- add dedicated category and category translation factories that seed the required `image_url`
- ensure category translations always carry a default placeholder path across repositories and tests
- register the `auth.customer` guard in the container and improve the page status AJAX response payload

## Testing
- `php artisan test` *(fails before execution because composer install cannot proceed: lock file requires Laravel 12 while the lock references 10, and composer update is blocked by Packagist 403 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68def20a7e008329856589f6fe241bd4