### PR TITLE
Fix page translation image defaults and auth guard binding

### DIFF
--- a/app/Models/Page.php
+++ b/app/Models/Page.php
@@ -11,6 +11,10 @@ class Page extends Model
 
     protected $fillable = ['slug', 'status'];
 
+    protected $casts = [
+        'status' => 'boolean',
+    ];
+
     public function translations()
     {
         return $this->hasMany(PageTranslation::class);

--- a/database/factories/PageTranslationFactory.php
+++ b/database/factories/PageTranslationFactory.php
@@ -20,7 +20,7 @@ class PageTranslationFactory extends Factory
             'language_code' => $this->faker->unique()->lexify('??'),
             'title' => $this->faker->sentence(3),
             'content' => $this->faker->paragraph(),
-            'image_url' => null,
+            'image_url' => 'pages/'.$this->faker->unique()->uuid().'.jpg',
         ];
     }
 }

--- a/tests/Feature/AdminPageBrowsingTest.php
+++ b/tests/Feature/AdminPageBrowsingTest.php
@@ -369,7 +369,7 @@ class AdminPageBrowsingTest extends TestCase
             'language_code' => 'en',
             'title' => 'About us',
             'content' => 'About page content',
-            'image_url' => null,
+            'image_url' => 'pages/about-us.jpg',
         ]);
 
         SiteSetting::create([

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -7,4 +7,13 @@ use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
 abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->app->singleton('auth.customer', function ($app) {
+            return $app['auth']->guard('customer');
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- provide default image URLs for generated page translations and update the admin browsing seed data accordingly
- ensure the customer authentication guard binding is restored within the test bootstrap
- cast page status values to booleans so the AJAX status endpoint returns the expected payload

## Testing
- php -l app/Models/Page.php
- php -l database/factories/PageTranslationFactory.php
- php -l tests/Feature/AdminPageBrowsingTest.php
- php -l tests/TestCase.php

------
https://chatgpt.com/codex/tasks/task_e_68def53b79848329aede28d70d07cf11