### PR TITLE
Add factories for application models

### DIFF
--- a/database/factories/AttributeFactory.php
+++ b/database/factories/AttributeFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Attribute;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Attribute>
+ */
+class AttributeFactory extends Factory
+{
+    protected $model = Attribute::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->unique()->word(),
+        ];
+    }
+}

--- a/database/factories/AttributeValueFactory.php
+++ b/database/factories/AttributeValueFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Attribute;
+use App\Models\AttributeValue;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<AttributeValue>
+ */
+class AttributeValueFactory extends Factory
+{
+    protected $model = AttributeValue::class;
+
+    public function definition(): array
+    {
+        return [
+            'attribute_id' => Attribute::factory(),
+            'value' => $this->faker->unique()->word(),
+        ];
+    }
+}

--- a/database/factories/AttributeValueTranslationFactory.php
+++ b/database/factories/AttributeValueTranslationFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AttributeValue;
+use App\Models\AttributeValueTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<AttributeValueTranslation>
+ */
+class AttributeValueTranslationFactory extends Factory
+{
+    protected $model = AttributeValueTranslation::class;
+
+    public function definition(): array
+    {
+        return [
+            'attribute_value_id' => AttributeValue::factory(),
+            'language_code' => $this->faker->unique()->languageCode(),
+            'translated_value' => $this->faker->words(3, true),
+        ];
+    }
+}

--- a/database/factories/BannerFactory.php
+++ b/database/factories/BannerFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Banner;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Banner>
+ */
+class BannerFactory extends Factory
+{
+    protected $model = Banner::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->sentence(3),
+            'status' => $this->faker->boolean(85),
+            'type' => $this->faker->randomElement(['homepage', 'category', 'product']),
+        ];
+    }
+}

--- a/database/factories/BannerTranslationFactory.php
+++ b/database/factories/BannerTranslationFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Banner;
+use App\Models\BannerTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<BannerTranslation>
+ */
+class BannerTranslationFactory extends Factory
+{
+    protected $model = BannerTranslation::class;
+
+    public function definition(): array
+    {
+        return [
+            'banner_id' => Banner::factory(),
+            'language_code' => $this->faker->unique()->languageCode(),
+            'title' => $this->faker->sentence(4),
+            'description' => $this->faker->paragraph(),
+            'image_url' => $this->faker->imageUrl(),
+            'type' => $this->faker->randomElement(['homepage', 'category', 'product']),
+        ];
+    }
+}

--- a/database/factories/BrandFactory.php
+++ b/database/factories/BrandFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Brand;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Brand>
+ */
+class BrandFactory extends Factory
+{
+    protected $model = Brand::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->company();
+
+        return [
+            'slug' => Str::slug($name) . '-' . $this->faker->unique()->numberBetween(100, 999),
+            'logo_url' => $this->faker->imageUrl(),
+            'status' => $this->faker->boolean(90),
+        ];
+    }
+}

--- a/database/factories/BrandTranslationFactory.php
+++ b/database/factories/BrandTranslationFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Brand;
+use App\Models\BrandTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<BrandTranslation>
+ */
+class BrandTranslationFactory extends Factory
+{
+    protected $model = BrandTranslation::class;
+
+    public function definition(): array
+    {
+        return [
+            'brand_id' => Brand::factory(),
+            'locale' => $this->faker->unique()->languageCode(),
+            'name' => $this->faker->company(),
+            'description' => $this->faker->paragraph(),
+        ];
+    }
+}

--- a/database/factories/CouponFactory.php
+++ b/database/factories/CouponFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Coupon;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Coupon>
+ */
+class CouponFactory extends Factory
+{
+    protected $model = Coupon::class;
+
+    public function definition(): array
+    {
+        return [
+            'code' => strtoupper($this->faker->unique()->bothify('SAVE##??')),
+            'discount' => $this->faker->numberBetween(5, 50),
+            'type' => $this->faker->randomElement(['percentage', 'fixed']),
+            'expires_at' => $this->faker->optional()->dateTimeBetween('now', '+1 year'),
+        ];
+    }
+}

--- a/database/factories/CurrencyFactory.php
+++ b/database/factories/CurrencyFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Currency;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Currency>
+ */
+class CurrencyFactory extends Factory
+{
+    protected $model = Currency::class;
+
+    public function definition(): array
+    {
+        $code = strtoupper($this->faker->unique()->currencyCode());
+
+        return [
+            'name' => $this->faker->currencyCode(),
+            'code' => $code,
+            'symbol' => $this->faker->randomElement(['$', '€', '£', '¥', '₹']),
+            'exchange_rate' => $this->faker->randomFloat(4, 0.5, 2.0),
+        ];
+    }
+}

--- a/database/factories/MenuFactory.php
+++ b/database/factories/MenuFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Menu;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+
+/**
+ * @extends Factory<Menu>
+ */
+class MenuFactory extends Factory
+{
+    protected $model = Menu::class;
+
+    public function definition(): array
+    {
+        return [
+            'title' => $this->faker->words(2, true),
+            'status' => $this->faker->boolean(90),
+            'date' => Carbon::instance($this->faker->dateTimeThisYear()),
+        ];
+    }
+}

--- a/database/factories/MenuItemFactory.php
+++ b/database/factories/MenuItemFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Menu;
+use App\Models\MenuItem;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<MenuItem>
+ */
+class MenuItemFactory extends Factory
+{
+    protected $model = MenuItem::class;
+
+    public function definition(): array
+    {
+        $title = $this->faker->words(2, true);
+
+        return [
+            'menu_id' => Menu::factory(),
+            'slug' => Str::slug($title) . '-' . $this->faker->unique()->numberBetween(100, 999),
+            'order_number' => $this->faker->numberBetween(1, 20),
+            'parent_id' => null,
+        ];
+    }
+}

--- a/database/factories/MenuItemTranslationFactory.php
+++ b/database/factories/MenuItemTranslationFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\MenuItem;
+use App\Models\MenuItemTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<MenuItemTranslation>
+ */
+class MenuItemTranslationFactory extends Factory
+{
+    protected $model = MenuItemTranslation::class;
+
+    public function definition(): array
+    {
+        return [
+            'menu_item_id' => MenuItem::factory(),
+            'language_code' => $this->faker->unique()->languageCode(),
+            'title' => $this->faker->words(2, true),
+        ];
+    }
+}

--- a/database/factories/OrderDetailFactory.php
+++ b/database/factories/OrderDetailFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Order;
+use App\Models\OrderDetail;
+use App\Models\Product;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<OrderDetail>
+ */
+class OrderDetailFactory extends Factory
+{
+    protected $model = OrderDetail::class;
+
+    public function definition(): array
+    {
+        return [
+            'order_id' => Order::factory(),
+            'product_id' => Product::factory(),
+            'quantity' => $this->faker->numberBetween(1, 5),
+            'price' => $this->faker->randomFloat(2, 5, 200),
+        ];
+    }
+}

--- a/database/factories/OrderFactory.php
+++ b/database/factories/OrderFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Customer;
+use App\Models\Order;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Order>
+ */
+class OrderFactory extends Factory
+{
+    protected $model = Order::class;
+
+    public function definition(): array
+    {
+        return [
+            'customer_id' => Customer::factory(),
+            'guest_email' => null,
+            'total_amount' => $this->faker->randomFloat(2, 10, 500),
+            'status' => $this->faker->randomElement(['pending', 'processing', 'completed', 'cancelled']),
+        ];
+    }
+}

--- a/database/factories/PaymentFactory.php
+++ b/database/factories/PaymentFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Order;
+use App\Models\Payment;
+use App\Models\PaymentGateway;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Payment>
+ */
+class PaymentFactory extends Factory
+{
+    protected $model = Payment::class;
+
+    public function definition(): array
+    {
+        return [
+            'order_id' => Order::factory(),
+            'gateway_id' => PaymentGateway::factory(),
+            'amount' => $this->faker->randomFloat(2, 10, 500),
+            'currency' => $this->faker->currencyCode(),
+            'status' => $this->faker->randomElement(['pending', 'paid', 'failed', 'refunded']),
+            'transaction_id' => $this->faker->uuid(),
+            'response' => ['transaction' => $this->faker->uuid()],
+            'meta' => ['ip' => $this->faker->ipv4()],
+        ];
+    }
+}

--- a/database/factories/PaymentGatewayConfigFactory.php
+++ b/database/factories/PaymentGatewayConfigFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\PaymentGateway;
+use App\Models\PaymentGatewayConfig;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<PaymentGatewayConfig>
+ */
+class PaymentGatewayConfigFactory extends Factory
+{
+    protected $model = PaymentGatewayConfig::class;
+
+    public function definition(): array
+    {
+        return [
+            'gateway_id' => PaymentGateway::factory(),
+            'key_name' => $this->faker->unique()->word(),
+            'key_value' => $this->faker->sha256(),
+            'is_encrypted' => $this->faker->boolean(20),
+            'environment' => $this->faker->randomElement(['production', 'sandbox']),
+        ];
+    }
+}

--- a/database/factories/PaymentGatewayFactory.php
+++ b/database/factories/PaymentGatewayFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\PaymentGateway;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<PaymentGateway>
+ */
+class PaymentGatewayFactory extends Factory
+{
+    protected $model = PaymentGateway::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->unique()->company();
+
+        return [
+            'name' => $name,
+            'code' => Str::slug($name),
+            'description' => $this->faker->sentence(),
+            'is_active' => $this->faker->boolean(90),
+        ];
+    }
+}

--- a/database/factories/ProductAttributeValueFactory.php
+++ b/database/factories/ProductAttributeValueFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AttributeValue;
+use App\Models\Product;
+use App\Models\ProductAttributeValue;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ProductAttributeValue>
+ */
+class ProductAttributeValueFactory extends Factory
+{
+    protected $model = ProductAttributeValue::class;
+
+    public function definition(): array
+    {
+        return [
+            'product_id' => Product::factory(),
+            'attribute_value_id' => AttributeValue::factory(),
+        ];
+    }
+}

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Brand;
+use App\Models\Category;
+use App\Models\Product;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Product>
+ */
+class ProductFactory extends Factory
+{
+    protected $model = Product::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->words(3, true);
+
+        return [
+            'category_id' => Category::factory(),
+            'brand_id' => Brand::factory(),
+            'seller_id' => null,
+            'shop_id' => null,
+            'price' => $this->faker->randomFloat(2, 10, 500),
+            'stock' => $this->faker->numberBetween(0, 100),
+            'status' => $this->faker->randomElement(['draft', 'published', 'archived']),
+            'slug' => Str::slug($name) . '-' . $this->faker->unique()->numberBetween(1000, 9999),
+            'currency' => $this->faker->currencyCode(),
+            'SKU' => strtoupper($this->faker->unique()->bothify('SKU-####')), 
+            'weight' => $this->faker->randomFloat(2, 0.1, 10),
+            'dimensions' => $this->faker->numberBetween(10, 100) . 'x' . $this->faker->numberBetween(10, 100) . 'x' . $this->faker->numberBetween(10, 100),
+            'product_type' => $this->faker->randomElement(['simple', 'variable']),
+            'image_url' => $this->faker->imageUrl(),
+            'vendor_id' => null,
+        ];
+    }
+}

--- a/database/factories/ProductImageFactory.php
+++ b/database/factories/ProductImageFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Product;
+use App\Models\ProductImage;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ProductImage>
+ */
+class ProductImageFactory extends Factory
+{
+    protected $model = ProductImage::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->words(2, true),
+            'image_url' => $this->faker->imageUrl(),
+            'type' => $this->faker->randomElement(['thumb', 'gallery']),
+            'product_id' => Product::factory(),
+        ];
+    }
+}

--- a/database/factories/ProductReviewFactory.php
+++ b/database/factories/ProductReviewFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Customer;
+use App\Models\Product;
+use App\Models\ProductReview;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ProductReview>
+ */
+class ProductReviewFactory extends Factory
+{
+    protected $model = ProductReview::class;
+
+    public function definition(): array
+    {
+        return [
+            'customer_id' => Customer::factory(),
+            'product_id' => Product::factory(),
+            'rating' => $this->faker->numberBetween(1, 5),
+            'review' => $this->faker->sentence(),
+            'is_approved' => $this->faker->boolean(80),
+        ];
+    }
+}

--- a/database/factories/ProductTranslationFactory.php
+++ b/database/factories/ProductTranslationFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Product;
+use App\Models\ProductTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ProductTranslation>
+ */
+class ProductTranslationFactory extends Factory
+{
+    protected $model = ProductTranslation::class;
+
+    public function definition(): array
+    {
+        $locale = $this->faker->unique()->languageCode();
+
+        return [
+            'product_id' => Product::factory(),
+            'locale' => $locale,
+            'language_code' => $locale,
+            'name' => $this->faker->words(3, true),
+            'description' => $this->faker->paragraph(),
+            'short_description' => $this->faker->sentence(),
+            'tags' => implode(',', $this->faker->words(3)),
+        ];
+    }
+}

--- a/database/factories/ProductVariantAttributeValueFactory.php
+++ b/database/factories/ProductVariantAttributeValueFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\AttributeValue;
+use App\Models\Product;
+use App\Models\ProductVariant;
+use App\Models\ProductVariantAttributeValue;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ProductVariantAttributeValue>
+ */
+class ProductVariantAttributeValueFactory extends Factory
+{
+    protected $model = ProductVariantAttributeValue::class;
+
+    public function definition(): array
+    {
+        return [
+            'product_variant_id' => ProductVariant::factory(),
+            'attribute_value_id' => AttributeValue::factory(),
+            'product_id' => Product::factory(),
+        ];
+    }
+}

--- a/database/factories/ProductVariantFactory.php
+++ b/database/factories/ProductVariantFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Product;
+use App\Models\ProductVariant;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<ProductVariant>
+ */
+class ProductVariantFactory extends Factory
+{
+    protected $model = ProductVariant::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->words(2, true);
+
+        return [
+            'product_id' => Product::factory(),
+            'variant_slug' => Str::slug($name) . '-' . $this->faker->unique()->numberBetween(1000, 9999),
+            'price' => $this->faker->randomFloat(2, 10, 300),
+            'discount_price' => $this->faker->optional(0.3)->randomFloat(2, 5, 250),
+            'stock' => $this->faker->numberBetween(0, 100),
+            'SKU' => strtoupper($this->faker->unique()->bothify('VAR-####')),
+            'barcode' => $this->faker->ean13(),
+            'is_primary' => $this->faker->boolean(20),
+            'weight' => $this->faker->randomFloat(2, 0.1, 5),
+            'dimensions' => $this->faker->numberBetween(5, 50) . 'x' . $this->faker->numberBetween(5, 50) . 'x' . $this->faker->numberBetween(5, 50),
+        ];
+    }
+}

--- a/database/factories/ProductVariantTranslationFactory.php
+++ b/database/factories/ProductVariantTranslationFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ProductVariant;
+use App\Models\ProductVariantTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ProductVariantTranslation>
+ */
+class ProductVariantTranslationFactory extends Factory
+{
+    protected $model = ProductVariantTranslation::class;
+
+    public function definition(): array
+    {
+        return [
+            'product_variant_id' => ProductVariant::factory(),
+            'language_code' => $this->faker->unique()->languageCode(),
+            'name' => $this->faker->words(3, true),
+        ];
+    }
+}

--- a/database/factories/RefundFactory.php
+++ b/database/factories/RefundFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Payment;
+use App\Models\Refund;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Refund>
+ */
+class RefundFactory extends Factory
+{
+    protected $model = Refund::class;
+
+    public function definition(): array
+    {
+        return [
+            'payment_id' => Payment::factory(),
+            'amount' => $this->faker->randomFloat(2, 5, 200),
+            'currency' => $this->faker->currencyCode(),
+            'status' => $this->faker->randomElement(['pending', 'processed', 'failed']),
+            'refund_id' => $this->faker->uuid(),
+            'reason' => $this->faker->sentence(),
+            'response' => ['reference' => $this->faker->uuid()],
+        ];
+    }
+}

--- a/database/factories/ShippingAddressFactory.php
+++ b/database/factories/ShippingAddressFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Customer;
+use App\Models\Order;
+use App\Models\ShippingAddress;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ShippingAddress>
+ */
+class ShippingAddressFactory extends Factory
+{
+    protected $model = ShippingAddress::class;
+
+    public function definition(): array
+    {
+        return [
+            'order_id' => Order::factory(),
+            'customer_id' => Customer::factory(),
+            'name' => $this->faker->name(),
+            'phone' => $this->faker->phoneNumber(),
+            'address' => $this->faker->streetAddress(),
+            'city' => $this->faker->city(),
+            'postal_code' => $this->faker->postcode(),
+            'country' => $this->faker->country(),
+        ];
+    }
+}

--- a/database/factories/ShopFactory.php
+++ b/database/factories/ShopFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Shop;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<Shop>
+ */
+class ShopFactory extends Factory
+{
+    protected $model = Shop::class;
+
+    public function definition(): array
+    {
+        $name = $this->faker->company();
+
+        return [
+            'seller_id' => null,
+            'name' => $name,
+            'slug' => Str::slug($name) . '-' . $this->faker->unique()->numberBetween(100, 999),
+            'logo' => $this->faker->imageUrl(),
+            'description' => $this->faker->sentence(),
+            'status' => $this->faker->randomElement(['active', 'inactive']),
+        ];
+    }
+}

--- a/database/factories/SiteSettingFactory.php
+++ b/database/factories/SiteSettingFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SiteSetting;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SiteSetting>
+ */
+class SiteSettingFactory extends Factory
+{
+    protected $model = SiteSetting::class;
+
+    public function definition(): array
+    {
+        return [
+            'site_name' => $this->faker->company(),
+            'tagline' => $this->faker->catchPhrase(),
+            'meta_title' => $this->faker->sentence(),
+            'meta_description' => $this->faker->paragraph(),
+            'meta_keywords' => implode(',', $this->faker->words(4)),
+            'contact_email' => $this->faker->companyEmail(),
+            'contact_phone' => $this->faker->phoneNumber(),
+            'address' => $this->faker->address(),
+            'footer_text' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/factories/SocialMediaLinkFactory.php
+++ b/database/factories/SocialMediaLinkFactory.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SocialMediaLink;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SocialMediaLink>
+ */
+class SocialMediaLinkFactory extends Factory
+{
+    protected $model = SocialMediaLink::class;
+
+    public function definition(): array
+    {
+        $platform = $this->faker->randomElement(['facebook', 'twitter', 'instagram', 'linkedin']);
+
+        return [
+            'type' => $this->faker->randomElement(['primary', 'secondary']),
+            'platform' => $platform,
+            'link' => 'https://www.' . $platform . '.com/' . $this->faker->userName(),
+        ];
+    }
+}

--- a/database/factories/SocialMediaLinkTranslationFactory.php
+++ b/database/factories/SocialMediaLinkTranslationFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\SocialMediaLink;
+use App\Models\SocialMediaLinkTranslation;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SocialMediaLinkTranslation>
+ */
+class SocialMediaLinkTranslationFactory extends Factory
+{
+    protected $model = SocialMediaLinkTranslation::class;
+
+    public function definition(): array
+    {
+        return [
+            'social_media_link_id' => SocialMediaLink::factory(),
+            'language_code' => $this->faker->unique()->languageCode(),
+            'name' => $this->faker->words(2, true),
+        ];
+    }
+}

--- a/database/factories/StoreSettingFactory.php
+++ b/database/factories/StoreSettingFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\StoreSetting;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<StoreSetting>
+ */
+class StoreSettingFactory extends Factory
+{
+    protected $model = StoreSetting::class;
+
+    public function definition(): array
+    {
+        return [
+            'key' => Str::snake($this->faker->unique()->words(2, true)),
+            'value' => $this->faker->sentence(),
+        ];
+    }
+}

--- a/database/factories/VendorFactory.php
+++ b/database/factories/VendorFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Vendor;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Vendor>
+ */
+class VendorFactory extends Factory
+{
+    protected $model = Vendor::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => $this->faker->name(),
+            'email' => $this->faker->unique()->safeEmail(),
+            'password' => 'password',
+            'phone' => $this->faker->phoneNumber(),
+            'status' => $this->faker->randomElement(['active', 'inactive']),
+            'avatar' => $this->faker->imageUrl(),
+        ];
+    }
+}

--- a/database/factories/WishlistFactory.php
+++ b/database/factories/WishlistFactory.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Customer;
+use App\Models\Product;
+use App\Models\Wishlist;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Wishlist>
+ */
+class WishlistFactory extends Factory
+{
+    protected $model = Wishlist::class;
+
+    public function definition(): array
+    {
+        return [
+            'customer_id' => Customer::factory(),
+            'product_id' => Product::factory(),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- add factories for each application model under the Database\Factories namespace
- provide realistic default attribute values and relationships to support seeding and testing

## Testing
- find database/factories -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68def5e32e148329af0eaa82dc54bedb