### PR TITLE
Add language tabbed translation inputs to product variants form

### DIFF
--- a/resources/views/admin/product_variants/form.blade.php
+++ b/resources/views/admin/product_variants/form.blade.php
@@ -41,7 +41,7 @@
     @endif
 
     <x-admin.card class="mt-6">
-        <form action="{{ $formAction }}" method="POST" class="space-y-8">
+        <form action="{{ $formAction }}" method="POST" class="space-y-8" id="productVariantForm">
             @csrf
             @if ($isEdit)
                 @method($formMethod)
@@ -227,56 +227,89 @@
                     </div>
                 </div>
 
-                <div class="mt-6 grid gap-6 md:grid-cols-2">
-                    @foreach ($languages as $language)
-                        @php
-                            $langCode = $language->code;
-                            $languageName = ucwords($language->name ?? $langCode);
-                            $existingTranslation = $isEdit && $productVariant
-                                ? $productVariant->translations->firstWhere('locale', $langCode)
-                                : null;
-                            $nameValue = old("translations.$langCode.name", $existingTranslation->name ?? '');
-                            $valueValue = old("translations.$langCode.value", $existingTranslation->value ?? '');
-                        @endphp
-                        <div class="rounded-lg border border-gray-200 bg-secondary-50/40 p-4">
-                            <h3 class="text-sm font-semibold text-gray-700">{{ $languageName }}</h3>
-                            <div class="mt-4 space-y-4">
-                                <div>
-                                    <label for="translations_{{ $langCode }}_name" class="form-label">
-                                        {{ __('cms.product_variants.form_translation_name', ['language' => $languageName]) }}
-                                    </label>
-                                    <input
-                                        type="text"
-                                        name="translations[{{ $langCode }}][name]"
-                                        id="translations_{{ $langCode }}_name"
-                                        class="form-control"
-                                        value="{{ $nameValue }}"
-                                        required
-                                    >
-                                    @error('translations.' . $langCode . '.name')
-                                        <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
-                                    @enderror
-                                </div>
+                <div class="mt-6">
+                    <ul class="nav nav-tabs" id="productVariantLanguageTabs" role="tablist">
+                        @foreach ($languages as $language)
+                            @php
+                                $langCode = $language->code;
+                                $languageName = ucwords($language->name ?? $langCode);
+                                $hasTranslationErrors = $errors->has("translations.$langCode.name") || $errors->has("translations.$langCode.value");
+                            @endphp
+                            <li class="nav-item" role="presentation">
+                                <button
+                                    class="nav-link {{ $loop->first ? 'active' : '' }} {{ $hasTranslationErrors ? 'text-danger-600' : '' }}"
+                                    id="product-variant-{{ $langCode }}-tab"
+                                    data-bs-toggle="tab"
+                                    data-bs-target="#product-variant-{{ $langCode }}"
+                                    type="button"
+                                    role="tab"
+                                    aria-controls="product-variant-{{ $langCode }}"
+                                    aria-selected="{{ $loop->first ? 'true' : 'false' }}"
+                                >
+                                    {{ $languageName }}
+                                    @if ($hasTranslationErrors)
+                                        <span class="ms-1">*</span>
+                                    @endif
+                                </button>
+                            </li>
+                        @endforeach
+                    </ul>
 
-                                <div>
-                                    <label for="translations_{{ $langCode }}_value" class="form-label">
-                                        {{ __('cms.product_variants.form_translation_value', ['language' => $languageName]) }}
-                                    </label>
-                                    <input
-                                        type="text"
-                                        name="translations[{{ $langCode }}][value]"
-                                        id="translations_{{ $langCode }}_value"
-                                        class="form-control"
-                                        value="{{ $valueValue }}"
-                                        placeholder="{{ __('cms.product_variants.form_translation_placeholder') }}"
-                                    >
-                                    @error('translations.' . $langCode . '.value')
-                                        <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
-                                    @enderror
+                    <div class="tab-content mt-4" id="productVariantLanguageTabContent">
+                        @foreach ($languages as $language)
+                            @php
+                                $langCode = $language->code;
+                                $languageName = ucwords($language->name ?? $langCode);
+                                $existingTranslation = $isEdit && $productVariant
+                                    ? $productVariant->translations->firstWhere('locale', $langCode)
+                                    : null;
+                                $nameValue = old("translations.$langCode.name", $existingTranslation->name ?? '');
+                                $valueValue = old("translations.$langCode.value", $existingTranslation->value ?? '');
+                            @endphp
+                            <div
+                                class="tab-pane fade show {{ $loop->first ? 'active' : '' }} rounded-lg border border-gray-200 bg-secondary-50/40 p-4"
+                                id="product-variant-{{ $langCode }}"
+                                role="tabpanel"
+                                aria-labelledby="product-variant-{{ $langCode }}-tab"
+                            >
+                                <div class="space-y-4">
+                                    <div>
+                                        <label for="translations_{{ $langCode }}_name" class="form-label">
+                                            {{ __('cms.product_variants.form_translation_name', ['language' => $languageName]) }}
+                                        </label>
+                                        <input
+                                            type="text"
+                                            name="translations[{{ $langCode }}][name]"
+                                            id="translations_{{ $langCode }}_name"
+                                            class="form-control @error('translations.' . $langCode . '.name') is-invalid @enderror"
+                                            value="{{ $nameValue }}"
+                                            required
+                                        >
+                                        @error('translations.' . $langCode . '.name')
+                                            <div class="invalid-feedback d-block">{{ $message }}</div>
+                                        @enderror
+                                    </div>
+
+                                    <div>
+                                        <label for="translations_{{ $langCode }}_value" class="form-label">
+                                            {{ __('cms.product_variants.form_translation_value', ['language' => $languageName]) }}
+                                        </label>
+                                        <input
+                                            type="text"
+                                            name="translations[{{ $langCode }}][value]"
+                                            id="translations_{{ $langCode }}_value"
+                                            class="form-control @error('translations.' . $langCode . '.value') is-invalid @enderror"
+                                            value="{{ $valueValue }}"
+                                            placeholder="{{ __('cms.product_variants.form_translation_placeholder') }}"
+                                        >
+                                        @error('translations.' . $langCode . '.value')
+                                            <div class="invalid-feedback d-block">{{ $message }}</div>
+                                        @enderror
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                    @endforeach
+                        @endforeach
+                    </div>
                 </div>
             </section>
 
@@ -291,3 +324,29 @@
         </form>
     </x-admin.card>
 @endsection
+
+@push('scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const form = document.getElementById('productVariantForm');
+            if (!form) {
+                return;
+            }
+
+            const firstInvalid = form.querySelector('.is-invalid');
+            if (!firstInvalid) {
+                return;
+            }
+
+            const tabPane = firstInvalid.closest('.tab-pane');
+            if (!tabPane || typeof bootstrap === 'undefined') {
+                return;
+            }
+
+            const trigger = document.querySelector(`[data-bs-target="#${tabPane.id}"]`);
+            if (trigger) {
+                bootstrap.Tab.getOrCreateInstance(trigger).show();
+            }
+        });
+    </script>
+@endpush


### PR DESCRIPTION
## Summary
- replace the product variant translation grid with bootstrap language tabs for easier editing
- highlight translation errors per language and automatically focus the first tab that needs attention

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df0c4a4148832982916fa3311a5cac