### PR TITLE
Revamp admin brand localization and status handling

### DIFF
--- a/app/Http/Controllers/Admin/BrandController.php
+++ b/app/Http/Controllers/Admin/BrandController.php
@@ -10,6 +10,7 @@ use App\Models\Brand;
 use App\Models\Language;
 use App\Services\Admin\BrandService;
 use Illuminate\Http\Request;
+use Yajra\DataTables\Facades\DataTables;
 
 class BrandController extends Controller
 {
@@ -27,28 +28,33 @@ class BrandController extends Controller
 
     public function getData(Request $request)
     {
-        $brands = $this->brandService->getAllBrands();
+        $brands = $this->brandService->getBrandsForDataTable();
 
-        return datatables()
-            ->of($brands)
-            ->addColumn('action', function ($brand) {
-                return view('admin.brands.index', compact('brand'));
+        return DataTables::of($brands)
+            ->addColumn('name', fn (Brand $brand) => $this->resolveLocalizedName($brand))
+            ->editColumn('status', fn (Brand $brand) => $brand->status)
+            ->addColumn('action', fn () => '')
+            ->filterColumn('name', function ($query, $keyword) {
+                $query->whereHas('translations', function ($relation) use ($keyword) {
+                    $relation->where('name', 'like', "%{$keyword}%");
+                });
             })
-            ->make(true);
+            ->toJson();
     }
 
     public function create()
     {
-        return view('admin.brands.create');
+        $activeLanguages = Language::active()->get();
+
+        return view('admin.brands.create', compact('activeLanguages'));
     }
 
     public function store(BrandStoreRequest $request)
     {
-        $result = $this->brandService->store($request->all());
+        $data = $request->validated();
+        $data['logo_url'] = $request->file('logo_url');
 
-        if ($result instanceof \Illuminate\Support\MessageBag) {
-            return redirect()->back()->withErrors($result)->withInput();
-        }
+        $this->brandService->store($data);
 
         return redirect()->route('admin.brands.index')->with('success', __('cms.brands.created'));
     }
@@ -57,18 +63,17 @@ class BrandController extends Controller
     {
         $brand = Brand::with('translations')->findOrFail($id);
 
-        $languages = Language::active()->get();
+        $activeLanguages = Language::active()->get();
 
-        return view('admin.brands.edit', compact('brand', 'languages'));
+        return view('admin.brands.edit', compact('brand', 'activeLanguages'));
     }
 
     public function update(BrandUpdateRequest $request, $id)
     {
-        $result = $this->brandService->updateBrand($id, $request->all());
+        $data = $request->validated();
+        $data['logo_url'] = $request->file('logo_url');
 
-        if ($result instanceof \Illuminate\Support\MessageBag) {
-            return redirect()->back()->withErrors($result)->withInput();
-        }
+        $this->brandService->updateBrand($id, $data);
 
         return redirect()->route('admin.brands.index')->with('success', __('cms.brands.updated'));
     }
@@ -92,20 +97,26 @@ class BrandController extends Controller
 
     public function updateStatus(BrandStatusUpdateRequest $request)
     {
-        $brand = Brand::find($request->id);
-        $brand->status = $request->status;
+        $brand = Brand::findOrFail($request->id);
+        $brand->status = $request->input('status');
         $brand->save();
 
-        if ($brand) {
-            return response()->json([
-                'success' => true,
-                'message' => __('cms.brands.status_updated'),
-            ]);
-        } else {
-            return response()->json([
-                'success' => false,
-                'message' => 'Brand status could not be updated.',
-            ]);
-        }
+        return response()->json([
+            'success' => true,
+            'message' => __('cms.brands.status_updated'),
+            'status' => $brand->status,
+        ]);
+    }
+
+    protected function resolveLocalizedName(Brand $brand): string
+    {
+        $locale = app()->getLocale();
+        $fallback = config('app.fallback_locale');
+
+        $translation = $brand->translations->firstWhere('locale', $locale)
+            ?? ($fallback ? $brand->translations->firstWhere('locale', $fallback) : null)
+            ?? $brand->translations->first();
+
+        return $translation?->name ?? $brand->slug;
     }
 }

--- a/app/Http/Requests/Admin/BrandStatusUpdateRequest.php
+++ b/app/Http/Requests/Admin/BrandStatusUpdateRequest.php
@@ -23,7 +23,7 @@ class BrandStatusUpdateRequest extends FormRequest
     {
         return [
             'id' => 'required|exists:brands,id',
-            'status' => 'required|boolean',
+            'status' => 'required|string|in:active,inactive,discontinued',
         ];
     }
 
@@ -38,7 +38,8 @@ class BrandStatusUpdateRequest extends FormRequest
             'id.required' => __('validation.required', ['attribute' => 'brand ID']),
             'id.exists' => __('validation.exists', ['attribute' => 'brand']),
             'status.required' => __('validation.required', ['attribute' => 'status']),
-            'status.boolean' => __('validation.boolean', ['attribute' => 'status']),
+            'status.string' => __('validation.string', ['attribute' => 'status']),
+            'status.in' => __('validation.in', ['attribute' => 'status']),
         ];
     }
 }

--- a/app/Repositories/Admin/Brand/BrandRepository.php
+++ b/app/Repositories/Admin/Brand/BrandRepository.php
@@ -8,7 +8,7 @@ class BrandRepository implements BrandRepositoryInterface
 {
     public function getAll()
     {
-        return Brand::all();
+        return Brand::with('translations')->get();
     }
 
     public function find($id)

--- a/resources/views/admin/brands/partials/form.blade.php
+++ b/resources/views/admin/brands/partials/form.blade.php
@@ -3,6 +3,7 @@
     $isEdit = isset($brand) && $brand;
     $submitLabel = $submitLabel ?? ($isEdit ? __('cms.brands.update') : __('cms.brands.create'));
     $logoPreviewUrl = $logoPreviewUrl ?? null;
+    $activeLanguages = isset($activeLanguages) ? collect($activeLanguages) : collect();
 
     if (! $logoPreviewUrl && $isEdit && $brand->logo_url) {
         $logoPreviewUrl = filter_var($brand->logo_url, FILTER_VALIDATE_URL)

--- a/routes/web.php
+++ b/routes/web.php
@@ -51,7 +51,7 @@ Route::prefix('admin')->name('admin.')->group(function () {
 
     /* Brands */
     Route::get('/brands', [BrandController::class, 'index'])->name('brands.index');
-    Route::get('admin/brands/getdata', [BrandController::class, 'getData'])->name('brands.getData');
+    Route::get('brands/data', [BrandController::class, 'getData'])->name('brands.getData');
     Route::get('brands/{id}/edit', [BrandController::class, 'edit'])->name('brands.edit');
     Route::put('brands/{brand}', [BrandController::class, 'update'])->name('brands.update');
     Route::get('brands/create', [BrandController::class, 'create'])->name('brands.create');


### PR DESCRIPTION
## Summary
- serve localized brand data for the admin DataTable and ensure create/edit views receive the active language set for tab rendering
- harden brand status updates, slug generation, and translation sync within the service layer while updating validation rules to match enum values
- adjust brand routes and front-end status toggles to work with the new status workflow and localized labels

## Testing
- php artisan test *(fails: vendor/autoload.php is missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68df0c7b909c83299e0937e400c4ad8e