### PR TITLE
Refactor attribute translations into per-value language tabs

### DIFF
--- a/resources/views/admin/attributes/partials/form.blade.php
+++ b/resources/views/admin/attributes/partials/form.blade.php
@@ -64,79 +64,82 @@
     </x-admin.card>
 
     <x-admin.card :title="__('cms.attributes.attribute_values')">
-        <div id="attribute-values-container" class="space-y-3">
+        <div id="attribute-values-container" class="space-y-4">
             @foreach ($values as $index => $value)
-                <div class="attribute-value-row flex flex-col gap-2 md:flex-row md:items-start md:gap-3">
-                    <div class="flex-1">
-                        <input
-                            type="text"
-                            name="values[]"
-                            value="{{ $value }}"
-                            class="form-control @error('values.' . $index) is-invalid @enderror"
-                        >
-                        @error('values.' . $index)
-                            <div class="invalid-feedback d-block">{{ $message }}</div>
-                        @enderror
+                @php
+                    $rowId = 'attribute-value-row-' . $index;
+                @endphp
+                <div class="attribute-value-row space-y-4 rounded-lg border border-gray-200 p-4" data-row-id="{{ $rowId }}">
+                    <div class="flex flex-col gap-2 md:flex-row md:items-start md:gap-3">
+                        <div class="flex-1">
+                            <input
+                                type="text"
+                                name="values[]"
+                                value="{{ $value }}"
+                                class="form-control @error('values.' . $index) is-invalid @enderror"
+                            >
+                            @error('values.' . $index)
+                                <div class="invalid-feedback d-block">{{ $message }}</div>
+                            @enderror
+                        </div>
+                        <button type="button" class="btn btn-outline-danger attribute-value-remove self-start">
+                            {{ __('cms.attributes.remove_value') }}
+                        </button>
                     </div>
-                    <button type="button" class="btn btn-outline-danger attribute-value-remove self-start">
-                        {{ __('cms.attributes.remove_value') }}
-                    </button>
+
+                    <div class="translation-section">
+                        <ul class="nav nav-tabs attribute-language-tabs" id="{{ $rowId }}-tabs" role="tablist">
+                            @foreach ($languages as $language)
+                                @php
+                                    $code = $language->code;
+                                @endphp
+                                <li class="nav-item" role="presentation">
+                                    <button
+                                        class="nav-link {{ $loop->first ? 'active' : '' }}"
+                                        id="{{ $rowId }}-{{ $code }}-tab"
+                                        data-bs-toggle="tab"
+                                        data-bs-target="#{{ $rowId }}-{{ $code }}-panel"
+                                        type="button"
+                                        role="tab"
+                                        aria-controls="{{ $rowId }}-{{ $code }}-panel"
+                                        aria-selected="{{ $loop->first ? 'true' : 'false' }}"
+                                    >
+                                        {{ ucwords($language->name) }}
+                                    </button>
+                                </li>
+                            @endforeach
+                        </ul>
+                        <div class="tab-content mt-3" id="{{ $rowId }}-tab-content">
+                            @foreach ($languages as $language)
+                                @php
+                                    $code = $language->code;
+                                    $translationValue = $translations[$code][$index] ?? '';
+                                @endphp
+                                <div
+                                    class="tab-pane fade show {{ $loop->first ? 'active' : '' }}"
+                                    id="{{ $rowId }}-{{ $code }}-panel"
+                                    role="tabpanel"
+                                    aria-labelledby="{{ $rowId }}-{{ $code }}-tab"
+                                >
+                                    <input
+                                        type="text"
+                                        name="translations[{{ $code }}][]"
+                                        value="{{ $translationValue }}"
+                                        class="form-control @error('translations.' . $code . '.' . $index) is-invalid @enderror"
+                                    >
+                                    @error('translations.' . $code . '.' . $index)
+                                        <div class="invalid-feedback d-block">{{ $message }}</div>
+                                    @enderror
+                                </div>
+                            @endforeach
+                        </div>
+                    </div>
                 </div>
             @endforeach
         </div>
         <button type="button" id="add-attribute-value" class="btn btn-outline-primary mt-3">
             {{ __('cms.attributes.add_value') }}
         </button>
-    </x-admin.card>
-
-    <x-admin.card :title="__('cms.attributes.translations')">
-        <ul class="nav nav-tabs" id="languageTabs" role="tablist">
-            @foreach ($languages as $language)
-                <li class="nav-item" role="presentation">
-                    <button
-                        class="nav-link {{ $loop->first ? 'active' : '' }}"
-                        id="attribute-{{ $language->code }}-tab"
-                        data-bs-toggle="tab"
-                        data-bs-target="#attribute-{{ $language->code }}-panel"
-                        type="button"
-                        role="tab"
-                        aria-controls="attribute-{{ $language->code }}-panel"
-                        aria-selected="{{ $loop->first ? 'true' : 'false' }}"
-                    >
-                        {{ ucwords($language->name) }}
-                    </button>
-                </li>
-            @endforeach
-        </ul>
-        <div class="tab-content mt-3" id="languageTabContent">
-            @foreach ($languages as $language)
-                @php
-                    $code = $language->code;
-                @endphp
-                <div
-                    class="tab-pane fade show {{ $loop->first ? 'active' : '' }}"
-                    id="attribute-{{ $code }}-panel"
-                    role="tabpanel"
-                    aria-labelledby="attribute-{{ $code }}-tab"
-                >
-                    <div id="translation-container-{{ $code }}" class="space-y-3">
-                        @foreach ($translations[$code] as $translationIndex => $translationValue)
-                            <div class="translation-group">
-                                <input
-                                    type="text"
-                                    name="translations[{{ $code }}][]"
-                                    value="{{ $translationValue }}"
-                                    class="form-control @error('translations.' . $code . '.' . $translationIndex) is-invalid @enderror"
-                                >
-                                @error('translations.' . $code . '.' . $translationIndex)
-                                    <div class="invalid-feedback d-block">{{ $message }}</div>
-                                @enderror
-                            </div>
-                        @endforeach
-                    </div>
-                </div>
-            @endforeach
-        </div>
     </x-admin.card>
 
     <div class="flex flex-col-reverse gap-3 md:flex-row md:items-center md:justify-end">


### PR DESCRIPTION
## Summary
- merge attribute value and translation inputs into a single card with per-value language tabs
- update the dynamic form script to create and manage translation tabs for each attribute value row

## Testing
- php artisan test *(fails: vendor/autoload.php missing)*

------
https://chatgpt.com/codex/tasks/task_e_68df0c8eb1588329904fcf243586e656