### PR TITLE
Add demo seed data and tests for product variant creation

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -23,6 +23,7 @@ class DatabaseSeeder extends Seeder
             RefundSeeder::class,
             CustomerSeeder::class,
             CustomerAddressSeeder::class,
+            ProductVariantDemoSeeder::class,
         ]);
     }
 }

--- a/database/seeders/ProductVariantDemoSeeder.php
+++ b/database/seeders/ProductVariantDemoSeeder.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Language;
+use App\Models\Product;
+use App\Models\ProductVariant;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
+
+class ProductVariantDemoSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $languages = collect([
+            ['code' => 'en', 'name' => 'English'],
+            ['code' => 'es', 'name' => 'Spanish'],
+        ])->map(function (array $data) {
+            return Language::updateOrCreate(
+                ['code' => $data['code']],
+                [
+                    'name' => $data['name'],
+                    'translated_text' => $data['name'],
+                    'active' => true,
+                ]
+            );
+        });
+
+        $product = Product::firstWhere('slug', 'demo-product-variant');
+
+        if (! $product) {
+            $product = Product::factory()->create([
+                'slug' => 'demo-product-variant',
+                'SKU' => 'DEMO-PRODUCT',
+                'product_type' => 'variable',
+                'status' => 1,
+            ]);
+        }
+
+        foreach ($languages as $language) {
+            $product->translations()->updateOrCreate(
+                ['language_code' => $language->code],
+                [
+                    'locale' => $language->code,
+                    'name' => 'Demo Product '.Str::upper($language->code),
+                    'description' => 'Demo description for '.$language->name.' shoppers.',
+                    'short_description' => 'Demo short description',
+                    'tags' => 'demo,variant',
+                ]
+            );
+        }
+
+        $variantSlug = 'demo-variant-'.$product->id;
+
+        $variant = ProductVariant::firstWhere('variant_slug', $variantSlug);
+
+        if (! $variant) {
+            $variant = ProductVariant::factory()
+                ->for($product)
+                ->create([
+                    'variant_slug' => $variantSlug,
+                    'SKU' => 'DEMO-'.$product->id,
+                    'is_primary' => true,
+                ]);
+        }
+
+        foreach ($languages as $language) {
+            $variant->translations()->updateOrCreate(
+                ['language_code' => $language->code],
+                [
+                    'name' => 'Demo Variant '.Str::upper($language->code),
+                ]
+            );
+        }
+    }
+}

--- a/resources/views/admin/product_variants/create.blade.php
+++ b/resources/views/admin/product_variants/create.blade.php
@@ -1,1 +1,5 @@
-@include('admin.product_variants.form', ['isEdit' => false])
+@extends('admin.layouts.admin')
+
+@section('content')
+    @include('admin.product_variants.form', ['isEdit' => false])
+@endsection

--- a/resources/views/admin/product_variants/edit.blade.php
+++ b/resources/views/admin/product_variants/edit.blade.php
@@ -1,1 +1,5 @@
-@include('admin.product_variants.form', ['isEdit' => true])
+@extends('admin.layouts.admin')
+
+@section('content')
+    @include('admin.product_variants.form', ['isEdit' => true])
+@endsection

--- a/resources/views/admin/product_variants/form.blade.php
+++ b/resources/views/admin/product_variants/form.blade.php
@@ -1,5 +1,3 @@
-@extends('admin.layouts.admin')
-
 @php
     $isEdit = $isEdit ?? false;
     $productVariant = $productVariant ?? null;
@@ -26,206 +24,205 @@
     }
 @endphp
 
-@section('content')
-    <x-admin.page-header :title="$pageTitle" :description="$pageDescription">
-        <x-admin.button-link href="{{ route('admin.product_variants.index') }}" class="btn-outline">
-            {{ __('cms.product_variants.back_to_index') }}
-        </x-admin.button-link>
-    </x-admin.page-header>
+<x-admin.page-header :title="$pageTitle" :description="$pageDescription">
+    <x-admin.button-link href="{{ route('admin.product_variants.index') }}" class="btn-outline">
+        {{ __('cms.product_variants.back_to_index') }}
+    </x-admin.button-link>
+</x-admin.page-header>
 
-    @if (session('success'))
-        <div class="alert alert-success mt-6">
-            {{ session('success') }}
-        </div>
-    @endif
+@if (session('success'))
+    <div class="alert alert-success mt-6">
+        {{ session('success') }}
+    </div>
+@endif
 
-    @if ($errors->any())
-        <div class="alert alert-danger mt-6">
-            <p class="font-semibold">{{ __('cms.product_variants.form_validation_error') }}</p>
-            <ul class="mt-2 list-disc list-inside space-y-1 text-sm">
-                @foreach ($errors->all() as $error)
-                    <li>{{ $error }}</li>
-                @endforeach
-            </ul>
-        </div>
-    @endif
+@if ($errors->any())
+    <div class="alert alert-danger mt-6">
+        <p class="font-semibold">{{ __('cms.product_variants.form_validation_error') }}</p>
+        <ul class="mt-2 list-disc list-inside space-y-1 text-sm">
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
 
-    <x-admin.card class="mt-6">
-        <form action="{{ $formAction }}" method="POST" class="space-y-8" id="productVariantForm">
-            @csrf
-            @if ($isEdit)
-                @method($formMethod)
-            @endif
+<x-admin.card class="mt-6">
+    <form action="{{ $formAction }}" method="POST" class="space-y-8" id="productVariantForm">
+        @csrf
+        @if ($isEdit)
+            @method($formMethod)
+        @endif
 
-            <section>
-                <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-500">
-                    {{ __('cms.product_variants.form_section_details') }}
-                </h2>
-                <div class="mt-4 grid gap-6 md:grid-cols-2">
-                    <div>
-                        <label for="product_id" class="form-label">{{ __('cms.product_variants.form_product') }}</label>
-                        <select name="product_id" id="product_id" class="form-select" required>
-                            <option value="">{{ __('cms.product_variants.form_select_product') }}</option>
-                            @foreach ($products as $product)
-                                @php
-                                    $productName = optional($product->translation)->name
-                                        ?? $product->translations->first()?->name
-                                        ?? __('cms.products.unnamed_product');
-                                @endphp
-                                <option value="{{ $product->id }}" @selected(old('product_id', $productVariant?->product_id ?? '') == $product->id)>
-                                    {{ $productName }}
-                                </option>
-                            @endforeach
-                        </select>
-                        @error('product_id')
-                            <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
-                        @enderror
-                    </div>
-
-                    <div>
-                        <label for="variant_slug" class="form-label">{{ __('cms.product_variants.form_variant_slug') }}</label>
-                        <input
-                            type="text"
-                            name="variant_slug"
-                            id="variant_slug"
-                            class="form-control"
-                            value="{{ old('variant_slug', $productVariant?->variant_slug ?? '') }}"
-                            required
-                        >
-                        @error('variant_slug')
-                            <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
-                        @enderror
-                    </div>
-
-                    <div>
-                        <label for="name" class="form-label">{{ __('cms.product_variants.form_internal_name') }}</label>
-                        <input
-                            type="text"
-                            name="name"
-                            id="name"
-                            class="form-control"
-                            value="{{ old('name', $productVariant?->name ?? '') }}"
-                            required
-                        >
-                        @error('name')
-                            <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
-                        @enderror
-                    </div>
-
-                    <div>
-                        <label for="value" class="form-label">{{ __('cms.product_variants.form_value') }}</label>
-                        <input
-                            type="text"
-                            name="value"
-                            id="value"
-                            class="form-control"
-                            value="{{ old('value', $productVariant?->value ?? '') }}"
-                            required
-                        >
-                        @error('value')
-                            <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
-                        @enderror
-                    </div>
+        <section>
+            <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                {{ __('cms.product_variants.form_section_details') }}
+            </h2>
+            <div class="mt-4 grid gap-6 md:grid-cols-2">
+                <div>
+                    <label for="product_id" class="form-label">{{ __('cms.product_variants.form_product') }}</label>
+                    <select name="product_id" id="product_id" class="form-select" required>
+                        <option value="">{{ __('cms.product_variants.form_select_product') }}</option>
+                        @foreach ($products as $product)
+                            @php
+                                $productName = optional($product->translation)->name
+                                    ?? $product->translations->first()?->name
+                                    ?? __('cms.products.unnamed_product');
+                            @endphp
+                            <option value="{{ $product->id }}" @selected(old('product_id', $productVariant?->product_id ?? '') == $product->id)>
+                                {{ $productName }}
+                            </option>
+                        @endforeach
+                    </select>
+                    @error('product_id')
+                        <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
+                    @enderror
                 </div>
-            </section>
 
-            <section>
-                <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-500">
-                    {{ __('cms.product_variants.form_section_inventory') }}
-                </h2>
-                <div class="mt-4 grid gap-6 md:grid-cols-2">
-                    <div>
-                        <label for="price" class="form-label">{{ __('cms.product_variants.form_price') }}</label>
-                        <input
-                            type="number"
-                            step="0.01"
-                            name="price"
-                            id="price"
-                            class="form-control"
-                            value="{{ old('price', $productVariant?->price ?? '') }}"
-                            required
-                        >
-                        @error('price')
-                            <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
-                        @enderror
-                    </div>
-
-                    <div>
-                        <label for="discount_price" class="form-label">{{ __('cms.product_variants.form_discount_price') }}</label>
-                        <input
-                            type="number"
-                            step="0.01"
-                            name="discount_price"
-                            id="discount_price"
-                            class="form-control"
-                            value="{{ old('discount_price', $productVariant?->discount_price ?? '') }}"
-                        >
-                        @error('discount_price')
-                            <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
-                        @enderror
-                    </div>
-
-                    <div>
-                        <label for="stock" class="form-label">{{ __('cms.product_variants.form_stock') }}</label>
-                        <input
-                            type="number"
-                            name="stock"
-                            id="stock"
-                            class="form-control"
-                            value="{{ old('stock', $productVariant?->stock ?? '') }}"
-                            required
-                        >
-                        @error('stock')
-                            <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
-                        @enderror
-                    </div>
-
-                    <div>
-                        <label for="SKU" class="form-label">{{ __('cms.product_variants.form_sku') }}</label>
-                        <input
-                            type="text"
-                            name="SKU"
-                            id="SKU"
-                            class="form-control"
-                            value="{{ old('SKU', $productVariant?->SKU ?? '') }}"
-                            required
-                        >
-                        @error('SKU')
-                            <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
-                        @enderror
-                    </div>
-
-                    <div>
-                        <label for="weight" class="form-label">{{ __('cms.product_variants.form_weight') }}</label>
-                        <input
-                            type="text"
-                            name="weight"
-                            id="weight"
-                            class="form-control"
-                            value="{{ old('weight', $productVariant?->weight ?? '') }}"
-                        >
-                        @error('weight')
-                            <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
-                        @enderror
-                    </div>
-
-                    <div>
-                        <label for="dimensions" class="form-label">{{ __('cms.product_variants.form_dimensions') }}</label>
-                        <input
-                            type="text"
-                            name="dimensions"
-                            id="dimensions"
-                            class="form-control"
-                            value="{{ old('dimensions', $productVariant?->dimensions ?? '') }}"
-                        >
-                        @error('dimensions')
-                            <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
-                        @enderror
-                    </div>
+                <div>
+                    <label for="variant_slug" class="form-label">{{ __('cms.product_variants.form_variant_slug') }}</label>
+                    <input
+                        type="text"
+                        name="variant_slug"
+                        id="variant_slug"
+                        class="form-control"
+                        value="{{ old('variant_slug', $productVariant?->variant_slug ?? '') }}"
+                        required
+                    >
+                    @error('variant_slug')
+                        <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
+                    @enderror
                 </div>
-            </section>
 
-            <section x-data="{ activeTab: '{{ $initialTab }}' }">
+                <div>
+                    <label for="name" class="form-label">{{ __('cms.product_variants.form_internal_name') }}</label>
+                    <input
+                        type="text"
+                        name="name"
+                        id="name"
+                        class="form-control"
+                        value="{{ old('name', $productVariant?->name ?? '') }}"
+                        required
+                    >
+                    @error('name')
+                        <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div>
+                    <label for="value" class="form-label">{{ __('cms.product_variants.form_value') }}</label>
+                    <input
+                        type="text"
+                        name="value"
+                        id="value"
+                        class="form-control"
+                        value="{{ old('value', $productVariant?->value ?? '') }}"
+                        required
+                    >
+                    @error('value')
+                        <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
+                    @enderror
+                </div>
+            </div>
+        </section>
+
+        <section>
+            <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                {{ __('cms.product_variants.form_section_inventory') }}
+            </h2>
+            <div class="mt-4 grid gap-6 md:grid-cols-2">
+                <div>
+                    <label for="price" class="form-label">{{ __('cms.product_variants.form_price') }}</label>
+                    <input
+                        type="number"
+                        step="0.01"
+                        name="price"
+                        id="price"
+                        class="form-control"
+                        value="{{ old('price', $productVariant?->price ?? '') }}"
+                        required
+                    >
+                    @error('price')
+                        <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div>
+                    <label for="discount_price" class="form-label">{{ __('cms.product_variants.form_discount_price') }}</label>
+                    <input
+                        type="number"
+                        step="0.01"
+                        name="discount_price"
+                        id="discount_price"
+                        class="form-control"
+                        value="{{ old('discount_price', $productVariant?->discount_price ?? '') }}"
+                    >
+                    @error('discount_price')
+                        <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div>
+                    <label for="stock" class="form-label">{{ __('cms.product_variants.form_stock') }}</label>
+                    <input
+                        type="number"
+                        name="stock"
+                        id="stock"
+                        class="form-control"
+                        value="{{ old('stock', $productVariant?->stock ?? '') }}"
+                        required
+                    >
+                    @error('stock')
+                        <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div>
+                    <label for="SKU" class="form-label">{{ __('cms.product_variants.form_sku') }}</label>
+                    <input
+                        type="text"
+                        name="SKU"
+                        id="SKU"
+                        class="form-control"
+                        value="{{ old('SKU', $productVariant?->SKU ?? '') }}"
+                        required
+                    >
+                    @error('SKU')
+                        <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div>
+                    <label for="weight" class="form-label">{{ __('cms.product_variants.form_weight') }}</label>
+                    <input
+                        type="text"
+                        name="weight"
+                        id="weight"
+                        class="form-control"
+                        value="{{ old('weight', $productVariant?->weight ?? '') }}"
+                    >
+                    @error('weight')
+                        <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div>
+                    <label for="dimensions" class="form-label">{{ __('cms.product_variants.form_dimensions') }}</label>
+                    <input
+                        type="text"
+                        name="dimensions"
+                        id="dimensions"
+                        class="form-control"
+                        value="{{ old('dimensions', $productVariant?->dimensions ?? '') }}"
+                    >
+                    @error('dimensions')
+                        <p class="mt-2 text-sm text-danger-600">{{ $message }}</p>
+                    @enderror
+                </div>
+            </div>
+        </section>
+
+        <section x-data="{ activeTab: '{{ $initialTab }}' }">
                 <div class="flex items-start justify-between gap-4">
                     <div>
                         <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-500">
@@ -321,19 +318,18 @@
                         @endforeach
                     </div>
                 </div>
-            </section>
+        </section>
 
-            <div class="flex items-center justify-end gap-3 border-t border-gray-200 pt-6">
-                <x-admin.button-link href="{{ route('admin.product_variants.index') }}" class="btn-outline">
-                    {{ __('cms.product_variants.back_to_index') }}
-                </x-admin.button-link>
-                <button type="submit" class="btn btn-primary">
-                    {{ $isEdit ? __('cms.product_variants.update_button') : __('cms.product_variants.create_button') }}
-                </button>
-            </div>
-        </form>
-    </x-admin.card>
-@endsection
+        <div class="flex items-center justify-end gap-3 border-t border-gray-200 pt-6">
+            <x-admin.button-link href="{{ route('admin.product_variants.index') }}" class="btn-outline">
+                {{ __('cms.product_variants.back_to_index') }}
+            </x-admin.button-link>
+            <button type="submit" class="btn btn-primary">
+                {{ $isEdit ? __('cms.product_variants.update_button') : __('cms.product_variants.create_button') }}
+            </button>
+        </div>
+    </form>
+</x-admin.card>
 
 @push('scripts')
     <script>

--- a/tests/Feature/Admin/ProductVariants/ProductVariantCreatePageTest.php
+++ b/tests/Feature/Admin/ProductVariants/ProductVariantCreatePageTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature\Admin\ProductVariants;
+
+use App\Models\Product;
+use Database\Seeders\ProductVariantDemoSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProductVariantCreatePageTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_create_page_displays_seeded_products_and_languages(): void
+    {
+        $this->seed(ProductVariantDemoSeeder::class);
+
+        $response = $this->get(route('admin.product_variants.create'));
+
+        $response->assertOk();
+        $response->assertViewHas('products');
+        $response->assertViewHas('languages');
+
+        $product = Product::first();
+        $this->assertNotNull($product, 'A demo product should be available after seeding.');
+
+        $translatedName = optional($product->translations()->firstWhere('language_code', app()->getLocale()))?->name
+            ?? $product->translations()->first()?->name;
+
+        if ($translatedName) {
+            $response->assertSee($translatedName);
+        }
+    }
+}

--- a/tests/Feature/Database/ProductVariantDemoSeederTest.php
+++ b/tests/Feature/Database/ProductVariantDemoSeederTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Feature\Database;
+
+use App\Models\Language;
+use App\Models\Product;
+use App\Models\ProductVariant;
+use Database\Seeders\ProductVariantDemoSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ProductVariantDemoSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_seeder_creates_demo_variant_with_translations(): void
+    {
+        $this->seed(ProductVariantDemoSeeder::class);
+
+        $this->assertDatabaseHas('languages', [
+            'code' => 'en',
+            'active' => true,
+        ]);
+
+        $product = Product::first();
+        $this->assertNotNull($product);
+        $this->assertSame('variable', $product->product_type);
+
+        foreach (['en', 'es'] as $code) {
+            $this->assertTrue(
+                $product->translations()->where('language_code', $code)->exists(),
+                "Product translation missing for language code {$code}"
+            );
+        }
+
+        $variant = ProductVariant::first();
+        $this->assertNotNull($variant);
+        $this->assertTrue($variant->translations()->where('language_code', 'en')->exists());
+        $this->assertTrue($variant->translations()->where('language_code', 'es')->exists());
+    }
+
+    public function test_seeder_is_idempotent(): void
+    {
+        $this->seed(ProductVariantDemoSeeder::class);
+        $this->seed(ProductVariantDemoSeeder::class);
+
+        $this->assertSame(1, Language::where('code', 'en')->count());
+        $this->assertSame(1, Language::where('code', 'es')->count());
+        $this->assertSame(1, Product::count());
+        $this->assertSame(1, ProductVariant::count());
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated ProductVariantDemoSeeder that provisions demo languages, a variable product, and its variant translations while remaining idempotent
- register the new seeder in DatabaseSeeder so the demo records are created during database seeding
- add feature coverage asserting the seeder output and that the admin create page receives the seeded products and languages

## Testing
- not run (composer install requires GitHub authentication in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68df11463c0c83299599839ae56fd244