### PR TITLE
Ensure seeded orders stay idempotent and covered by tests

### DIFF
--- a/database/seeders/OrderSeeder.php
+++ b/database/seeders/OrderSeeder.php
@@ -2,61 +2,92 @@
 
 namespace Database\Seeders;
 
+use App\Models\Order;
+use App\Models\OrderDetail;
+use App\Models\Product;
+use App\Models\ShippingAddress;
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\DB;
 
 class OrderSeeder extends Seeder
 {
     public function run()
     {
-        $productIds = DB::table('products')->pluck('id')->take(2)->values();
+        $productIds = Product::query()->orderBy('id')->limit(2)->pluck('id');
         if ($productIds->count() < 2) {
             return;  // No products available; skip seeding orders to avoid FK errors
         }
 
-        $order1Id = DB::table('orders')->insertGetId([
-            'customer_id' => null,
-            'guest_email' => 'guest1@example.com',
-            'total_amount' => 300,
-            'status' => 'completed',
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
+        $orders = [
+            [
+                'guest_email' => 'guest1@example.com',
+                'status' => 'completed',
+                'items' => [
+                    ['product_id' => $productIds[0], 'quantity' => 2, 'price' => 100],
+                    ['product_id' => $productIds[1], 'quantity' => 1, 'price' => 100],
+                ],
+                'shipping' => [
+                    'name' => 'Guest One',
+                    'phone' => '+1-202-555-0101',
+                    'address' => '123 Demo Street',
+                    'city' => 'Demo City',
+                    'postal_code' => '10001',
+                    'country' => 'United States',
+                ],
+            ],
+            [
+                'guest_email' => 'guest2@example.com',
+                'status' => 'pending',
+                'items' => [
+                    ['product_id' => $productIds[0], 'quantity' => 3, 'price' => 50],
+                ],
+                'shipping' => [
+                    'name' => 'Guest Two',
+                    'phone' => '+1-202-555-0102',
+                    'address' => '456 Sample Avenue',
+                    'city' => 'Sampletown',
+                    'postal_code' => '30301',
+                    'country' => 'United States',
+                ],
+            ],
+        ];
 
-        $order2Id = DB::table('orders')->insertGetId([
-            'customer_id' => null,
-            'guest_email' => 'guest2@example.com',
-            'total_amount' => 150,
-            'status' => 'pending',
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
+        foreach ($orders as $payload) {
+            $total = collect($payload['items'])->reduce(
+                fn (float $carry, array $item) => $carry + ($item['quantity'] * $item['price']),
+                0.0
+            );
 
-        DB::table('order_details')->insert([
-            [
-                'order_id' => $order1Id,
-                'product_id' => $productIds[0],
-                'quantity' => 2,
-                'price' => 100,
-                'created_at' => now(),
-                'updated_at' => now(),
-            ],
-            [
-                'order_id' => $order1Id,
-                'product_id' => $productIds[1],
-                'quantity' => 1,
-                'price' => 100,
-                'created_at' => now(),
-                'updated_at' => now(),
-            ],
-            [
-                'order_id' => $order2Id,
-                'product_id' => $productIds[0],
-                'quantity' => 3,
-                'price' => 50,
-                'created_at' => now(),
-                'updated_at' => now(),
-            ],
-        ]);
+            $order = Order::updateOrCreate(
+                ['guest_email' => $payload['guest_email']],
+                [
+                    'customer_id' => null,
+                    'status' => $payload['status'],
+                    'total_amount' => number_format($total, 2, '.', ''),
+                ]
+            );
+
+            foreach ($payload['items'] as $item) {
+                OrderDetail::updateOrCreate(
+                    [
+                        'order_id' => $order->id,
+                        'product_id' => $item['product_id'],
+                    ],
+                    [
+                        'quantity' => $item['quantity'],
+                        'price' => $item['price'],
+                    ]
+                );
+            }
+
+            ShippingAddress::updateOrCreate(
+                ['order_id' => $order->id],
+                array_merge(
+                    [
+                        'customer_id' => null,
+                    ],
+                    $payload['shipping']
+                )
+            );
+        }
     }
 }

--- a/database/seeders/PaymentSeeder.php
+++ b/database/seeders/PaymentSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\Order;
 use App\Models\Payment;
 use App\Models\PaymentGateway;
+use App\Models\ShippingAddress;
 use App\Models\User;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Str;
@@ -26,23 +27,40 @@ class PaymentSeeder extends Seeder
             ['name' => 'Stripe']
         );
 
-        $order = Order::create([
-            'customer_id' => null,
-            'guest_email' => 'guest@example.com',
-            'total_amount' => 100.00,
-            'status' => 'pending',
-        ]);
+        $order = Order::updateOrCreate(
+            ['guest_email' => 'guest@example.com'],
+            [
+                'customer_id' => null,
+                'total_amount' => 100.00,
+                'status' => 'pending',
+            ]
+        );
 
-        Payment::create([
-            'order_id' => $order->id,
-            'user_id' => $user->id,
-            'gateway_id' => $gateway->id,
-            'amount' => 100.00,
-            'currency' => 'USD',
-            'status' => 'completed',
-            'transaction_id' => Str::uuid(),
-            'response' => ['message' => 'Payment successful'],
-            'meta' => ['ip' => '127.0.0.1'],
-        ]);
+        ShippingAddress::updateOrCreate(
+            ['order_id' => $order->id],
+            [
+                'customer_id' => null,
+                'name' => 'Guest Checkout',
+                'phone' => '+1-202-555-0199',
+                'address' => '789 Example Road',
+                'city' => 'Seedville',
+                'postal_code' => '60601',
+                'country' => 'United States',
+            ]
+        );
+
+        if (! $order->payments()->exists()) {
+            Payment::create([
+                'order_id' => $order->id,
+                'user_id' => $user->id,
+                'gateway_id' => $gateway->id,
+                'amount' => 100.00,
+                'currency' => 'USD',
+                'status' => 'completed',
+                'transaction_id' => (string) Str::uuid(),
+                'response' => ['message' => 'Payment successful'],
+                'meta' => ['ip' => '127.0.0.1'],
+            ]);
+        }
     }
 }

--- a/tests/Feature/Database/OrderSeederTest.php
+++ b/tests/Feature/Database/OrderSeederTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\Database;
+
+use App\Models\Order;
+use App\Models\OrderDetail;
+use App\Models\Product;
+use App\Models\ShippingAddress;
+use Database\Seeders\OrderSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class OrderSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_order_seeder_populates_demo_orders_with_shipping_addresses(): void
+    {
+        Product::factory()->count(2)->create();
+
+        $this->seed(OrderSeeder::class);
+
+        $this->assertSame(2, Order::count());
+        $this->assertSame(2, ShippingAddress::count());
+        $this->assertSame(3, OrderDetail::count());
+
+        $this->assertDatabaseHas('shipping_addresses', [
+            'name' => 'Guest One',
+            'address' => '123 Demo Street',
+        ]);
+
+        $this->assertDatabaseHas('shipping_addresses', [
+            'name' => 'Guest Two',
+            'address' => '456 Sample Avenue',
+        ]);
+    }
+
+    public function test_order_seeder_is_idempotent(): void
+    {
+        Product::factory()->count(2)->create();
+
+        $this->seed(OrderSeeder::class);
+        $this->seed(OrderSeeder::class);
+
+        $this->assertSame(2, Order::count());
+        $this->assertSame(2, ShippingAddress::count());
+        $this->assertSame(3, OrderDetail::count());
+    }
+}

--- a/tests/Feature/Database/PaymentSeederTest.php
+++ b/tests/Feature/Database/PaymentSeederTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Feature\Database;
+
+use App\Models\Order;
+use App\Models\Payment;
+use App\Models\ShippingAddress;
+use Database\Seeders\PaymentSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class PaymentSeederTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_payment_seeder_creates_demo_payment_with_shipping_address(): void
+    {
+        $this->seed(PaymentSeeder::class);
+
+        $order = Order::where('guest_email', 'guest@example.com')->first();
+        $this->assertNotNull($order);
+
+        $this->assertTrue($order->shippingAddress()->exists());
+        $this->assertDatabaseHas('shipping_addresses', [
+            'order_id' => $order->id,
+            'name' => 'Guest Checkout',
+        ]);
+
+        $this->assertTrue($order->payments()->exists());
+        $this->assertSame(1, Payment::count());
+    }
+
+    public function test_payment_seeder_is_idempotent(): void
+    {
+        $this->seed(PaymentSeeder::class);
+        $this->seed(PaymentSeeder::class);
+
+        $order = Order::where('guest_email', 'guest@example.com')->first();
+        $this->assertNotNull($order);
+
+        $this->assertSame(1, ShippingAddress::count());
+        $this->assertSame(1, Payment::count());
+    }
+}


### PR DESCRIPTION
## Summary
- refactor the order seeder to create demo orders, details, and shipping addresses idempotently through Eloquent models
- update the payment seeder to reuse the demo order, populate its shipping address, and avoid duplicate payments
- add feature tests that exercise the order and payment seeders to confirm they create shipping data and remain idempotent

## Testing
- php artisan test --filter=OrderSeederTest *(fails: vendor/autoload.php missing because composer install is blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df11f494ac832984a9dd93ac1acf22