### PR TITLE
Revamp admin customer management

### DIFF
--- a/app/Http/Requests/Admin/CustomerStoreRequest.php
+++ b/app/Http/Requests/Admin/CustomerStoreRequest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class CustomerStoreRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'max:255', 'unique:customers,email'],
+            'password' => ['required', 'string', 'min:6'],
+            'phone' => ['nullable', 'string', 'max:20'],
+            'address' => ['nullable', 'string', 'max:500'],
+            'status' => ['required', Rule::in(['active', 'inactive'])],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'status.in' => __('validation.in', ['attribute' => __('cms.customers.status')]),
+        ];
+    }
+}

--- a/app/Http/Requests/Admin/CustomerUpdateRequest.php
+++ b/app/Http/Requests/Admin/CustomerUpdateRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class CustomerUpdateRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        $customerId = $this->route('customer')?->id ?? null;
+
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'email', 'max:255', Rule::unique('customers', 'email')->ignore($customerId)],
+            'password' => ['nullable', 'string', 'min:6'],
+            'phone' => ['nullable', 'string', 'max:20'],
+            'address' => ['nullable', 'string', 'max:500'],
+            'status' => ['required', Rule::in(['active', 'inactive'])],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'status.in' => __('validation.in', ['attribute' => __('cms.customers.status')]),
+        ];
+    }
+}

--- a/database/factories/CustomerFactory.php
+++ b/database/factories/CustomerFactory.php
@@ -23,4 +23,11 @@ class CustomerFactory extends Factory
             'status' => 'active',
         ];
     }
+
+    public function inactive(): self
+    {
+        return $this->state(fn () => [
+            'status' => 'inactive',
+        ]);
+    }
 }

--- a/database/seeders/CustomerSeeder.php
+++ b/database/seeders/CustomerSeeder.php
@@ -52,5 +52,8 @@ class CustomerSeeder extends Seeder
                 ]
             );
         }
+
+        Customer::factory()->count(12)->create();
+        Customer::factory()->inactive()->count(4)->create();
     }
 }

--- a/lang/en/cms.php
+++ b/lang/en/cms.php
@@ -344,12 +344,20 @@ return [
 
     'customers' => [
         'customer_list' => 'Customer List',
+        'index_title' => 'Customers',
+        'index_description' => 'View, search, and manage customer accounts in one place.',
 
         // Create form
         'create_title' => 'Create Customer',
         'create_description' => 'Add a new customer by providing their basic information.',
         'create_button' => 'Create Customer',
+        'create_button_short' => 'New Customer',
         'password' => 'Password',
+        'form_section_profile' => 'Profile details',
+        'form_section_profile_hint' => 'Basic information used to identify the customer across the platform.',
+        'form_section_account' => 'Account settings',
+        'form_section_account_hint' => 'Credentials and status that control access to the storefront.',
+        'address_placeholder' => 'Street, city, postal code, country…',
 
         // Table columns
         'id' => 'Id',
@@ -359,6 +367,22 @@ return [
         'address' => 'Address',
         'status' => 'Status',
         'actions' => 'Actions',
+
+        // Filters
+        'search_label' => 'Search customers',
+        'search_placeholder' => 'Search by name, email, or phone',
+        'filter_status_label' => 'Status',
+        'filter_status_all' => 'All statuses',
+        'apply_filters' => 'Apply filters',
+        'reset_filters' => 'Reset',
+
+        // Metrics
+        'metric_total' => 'Total customers',
+        'metric_total_hint' => 'Includes all active and inactive accounts.',
+        'metric_active' => 'Active customers',
+        'metric_active_hint' => 'Ready to shop and receive communications.',
+        'metric_inactive' => 'Inactive customers',
+        'metric_inactive_hint' => 'Accounts currently disabled or suspended.',
 
         // Status labels
         'active' => 'Active',
@@ -372,9 +396,13 @@ return [
 
         // Toastr messages
         'success_title' => 'Success',
+        'error_title' => 'Error',
         'deleted_title' => 'Deleted',
         'delete_success_message' => 'Customer deleted successfully!',
         'delete_error_message' => 'Error deleting customer!',
+
+        // Empty state
+        'empty_state_message' => 'No customers match your filters yet.',
 
         // Details view
         'view_button' => 'View',

--- a/resources/js/admin/customers/index.js
+++ b/resources/js/admin/customers/index.js
@@ -1,0 +1,159 @@
+import axios from 'axios';
+
+const getCsrfToken = () => {
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    return meta ? meta.getAttribute('content') : '';
+};
+
+const showToast = (type, message, title) => {
+    if (!window.toastr) {
+        return;
+    }
+
+    const toast = window.toastr[type] ?? window.toastr.info;
+    toast(message, title, {
+        closeButton: true,
+        progressBar: true,
+        positionClass: 'toast-top-right',
+        timeOut: 5000,
+    });
+};
+
+const removeRow = (customerId) => {
+    const trigger = document.querySelector(`[data-customer-delete="${customerId}"]`);
+    const row = trigger?.closest('tr');
+
+    if (!row) {
+        window.location.reload();
+        return;
+    }
+
+    const tbody = row.parentElement;
+    row.remove();
+
+    if (!tbody) {
+        return;
+    }
+
+    if (tbody.children.length === 0) {
+        const table = tbody.closest('[data-customers-table]');
+        const emptyMessage = table?.dataset.emptyMessage ?? '';
+        const columnCountValue = table?.dataset.columnCount ?? '1';
+        const columnCount = Number.parseInt(columnCountValue, 10);
+
+        const emptyRow = document.createElement('tr');
+        emptyRow.dataset.customersEmptyRow = '';
+
+        const emptyCell = document.createElement('td');
+        emptyCell.colSpan = Number.isNaN(columnCount) ? 1 : columnCount;
+        emptyCell.className = 'table-cell py-6 text-center text-sm text-gray-500';
+        emptyCell.textContent = emptyMessage;
+
+        emptyRow.appendChild(emptyCell);
+        tbody.appendChild(emptyRow);
+    }
+};
+
+const initializeCustomersModule = () => {
+    const modal = document.querySelector('[data-customer-delete-modal]');
+    if (!modal) {
+        return;
+    }
+
+    const confirmButton = modal.querySelector('[data-confirm-delete]');
+    const dismissTriggers = modal.querySelectorAll('[data-dismiss-modal]');
+    const labelElement = modal.querySelector('[data-customer-label]');
+
+    const deleteUrlTemplate = modal.dataset.deleteUrl;
+    const successTitle = modal.dataset.successTitle;
+    const successMessage = modal.dataset.successMessage;
+    const errorTitle = modal.dataset.errorTitle;
+    const errorMessage = modal.dataset.errorMessage;
+
+    let currentCustomerId = null;
+
+    const hideModal = () => {
+        modal.classList.add('hidden');
+        currentCustomerId = null;
+        if (labelElement) {
+            labelElement.textContent = '';
+        }
+        if (confirmButton) {
+            confirmButton.disabled = false;
+        }
+    };
+
+    const showModal = () => {
+        modal.classList.remove('hidden');
+    };
+
+    dismissTriggers.forEach((trigger) => {
+        trigger.addEventListener('click', hideModal);
+    });
+
+    modal.addEventListener('click', (event) => {
+        if (event.target === modal) {
+            hideModal();
+        }
+    });
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && !modal.classList.contains('hidden')) {
+            hideModal();
+        }
+    });
+
+    document.addEventListener('click', (event) => {
+        const button = event.target.closest?.('[data-customer-delete]');
+        if (!button) {
+            return;
+        }
+
+        currentCustomerId = button.dataset.customerDelete ?? null;
+        const customerLabel = button.dataset.customerLabel ?? '';
+
+        if (labelElement) {
+            labelElement.textContent = customerLabel;
+        }
+
+        showModal();
+    });
+
+    if (!confirmButton || !deleteUrlTemplate) {
+        return;
+    }
+
+    confirmButton.addEventListener('click', async () => {
+        if (!currentCustomerId) {
+            return;
+        }
+
+        confirmButton.disabled = true;
+
+        const csrfToken = getCsrfToken();
+        const deleteUrl = deleteUrlTemplate.replace('__CUSTOMER_ID__', currentCustomerId);
+
+        try {
+            const response = await axios.delete(deleteUrl, {
+                data: {
+                    _token: csrfToken,
+                },
+            });
+
+            if (response.data?.success) {
+                removeRow(currentCustomerId);
+                showToast('success', response.data?.message ?? successMessage, successTitle);
+                hideModal();
+            } else {
+                showToast('error', response.data?.message ?? errorMessage, errorTitle);
+            }
+        } catch (error) {
+            console.error('Failed to delete customer', error);
+            showToast('error', errorMessage, errorTitle);
+        } finally {
+            confirmButton.disabled = false;
+        }
+    });
+};
+
+document.addEventListener('DOMContentLoaded', initializeCustomersModule);

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,6 +1,7 @@
 import './bootstrap';
 import './admin/sidebar';
 import './admin/orders/index';
+import './admin/customers/index';
 
 document.addEventListener('click', function (event) {
     const target = event.target;

--- a/resources/views/admin/customers/create.blade.php
+++ b/resources/views/admin/customers/create.blade.php
@@ -1,88 +1,156 @@
 @extends('admin.layouts.admin')
 
 @section('content')
-    <div class="card mt-4">
-        <div class="card-header card-header-bg text-white d-flex justify-content-between align-items-center">
-            <h6 class="mb-0">{{ __('cms.customers.create_title') }}</h6>
-            <button type="button" class="btn btn-light btn-sm"
-                    data-url="{{ route('admin.customers.index') }}">{{ __('cms.customers.back_to_list') }}</button>
-        </div>
+    <x-admin.page-header
+        :title="__('cms.customers.create_title')"
+        :description="__('cms.customers.create_description')"
+    >
+        <x-admin.button-link href="{{ route('admin.customers.index') }}" class="btn-outline">
+            {{ __('cms.customers.back_to_list') }}
+        </x-admin.button-link>
+    </x-admin.page-header>
 
-        <div class="card-body">
-            <p class="text-muted mb-4">{{ __('cms.customers.create_description') }}</p>
+    <x-admin.card class="mt-6">
+        <form action="{{ route('admin.customers.store') }}" method="POST" class="grid gap-6">
+            @csrf
 
-            <form action="{{ route('admin.customers.store') }}" method="POST" class="row g-3">
-                @csrf
+            <div class="grid gap-6 lg:grid-cols-2">
+                <div class="space-y-4">
+                    <div>
+                        <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+                            {{ __('cms.customers.form_section_profile') }}
+                        </h3>
+                        <p class="mt-1 text-sm text-gray-500">
+                            {{ __('cms.customers.form_section_profile_hint') }}
+                        </p>
+                    </div>
 
-                <div class="col-md-6">
-                    <label for="name" class="form-label">{{ __('cms.customers.name') }}</label>
-                    <input type="text" name="name" id="name"
-                           class="form-control @error('name') is-invalid @enderror"
-                           value="{{ old('name') }}" maxlength="255" required>
-                    @error('name')
-                        <div class="invalid-feedback">{{ $message }}</div>
-                    @enderror
+                    <div class="grid gap-4">
+                        <div>
+                            <label for="name" class="form-label">{{ __('cms.customers.name') }}</label>
+                            <input
+                                id="name"
+                                type="text"
+                                name="name"
+                                value="{{ old('name') }}"
+                                maxlength="255"
+                                class="form-control @error('name') is-invalid @enderror"
+                                autocomplete="name"
+                                required
+                            >
+                            @error('name')
+                                <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                            @enderror
+                        </div>
+
+                        <div>
+                            <label for="email" class="form-label">{{ __('cms.customers.email') }}</label>
+                            <input
+                                id="email"
+                                type="email"
+                                name="email"
+                                value="{{ old('email') }}"
+                                maxlength="255"
+                                class="form-control @error('email') is-invalid @enderror"
+                                autocomplete="email"
+                                required
+                            >
+                            @error('email')
+                                <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                            @enderror
+                        </div>
+
+                        <div>
+                            <label for="phone" class="form-label">{{ __('cms.customers.phone') }}</label>
+                            <input
+                                id="phone"
+                                type="text"
+                                name="phone"
+                                value="{{ old('phone') }}"
+                                maxlength="20"
+                                class="form-control @error('phone') is-invalid @enderror"
+                                autocomplete="tel"
+                                placeholder="+1 555 0100"
+                            >
+                            @error('phone')
+                                <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                            @enderror
+                        </div>
+                    </div>
                 </div>
 
-                <div class="col-md-6">
-                    <label for="email" class="form-label">{{ __('cms.customers.email') }}</label>
-                    <input type="email" name="email" id="email"
-                           class="form-control @error('email') is-invalid @enderror"
-                           value="{{ old('email') }}" maxlength="255" required>
-                    @error('email')
-                        <div class="invalid-feedback">{{ $message }}</div>
-                    @enderror
-                </div>
+                <div class="space-y-4">
+                    <div>
+                        <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+                            {{ __('cms.customers.form_section_account') }}
+                        </h3>
+                        <p class="mt-1 text-sm text-gray-500">
+                            {{ __('cms.customers.form_section_account_hint') }}
+                        </p>
+                    </div>
 
-                <div class="col-md-6">
-                    <label for="password" class="form-label">{{ __('cms.customers.password') }}</label>
-                    <input type="password" name="password" id="password"
-                           class="form-control @error('password') is-invalid @enderror" minlength="6" required>
-                    @error('password')
-                        <div class="invalid-feedback">{{ $message }}</div>
-                    @enderror
-                </div>
+                    <div class="grid gap-4">
+                        <div>
+                            <label for="password" class="form-label">{{ __('cms.customers.password') }}</label>
+                            <input
+                                id="password"
+                                type="password"
+                                name="password"
+                                class="form-control @error('password') is-invalid @enderror"
+                                autocomplete="new-password"
+                                minlength="6"
+                                required
+                            >
+                            @error('password')
+                                <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                            @enderror
+                        </div>
 
-                <div class="col-md-6">
-                    <label for="phone" class="form-label">{{ __('cms.customers.phone') }}</label>
-                    <input type="text" name="phone" id="phone"
-                           class="form-control @error('phone') is-invalid @enderror"
-                           value="{{ old('phone') }}" maxlength="20">
-                    @error('phone')
-                        <div class="invalid-feedback">{{ $message }}</div>
-                    @enderror
-                </div>
+                        <div>
+                            <label for="status" class="form-label">{{ __('cms.customers.status') }}</label>
+                            <select
+                                id="status"
+                                name="status"
+                                class="form-select @error('status') is-invalid @enderror"
+                                required
+                            >
+                                @foreach ($statusOptions as $value => $label)
+                                    <option value="{{ $value }}" @selected(old('status', 'active') === $value)>
+                                        {{ $label }}
+                                    </option>
+                                @endforeach
+                            </select>
+                            @error('status')
+                                <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                            @enderror
+                        </div>
 
-                <div class="col-12">
-                    <label for="address" class="form-label">{{ __('cms.customers.address') }}</label>
-                    <textarea name="address" id="address" rows="3"
-                              class="form-control @error('address') is-invalid @enderror"
-                              maxlength="500">{{ old('address') }}</textarea>
-                    @error('address')
-                        <div class="invalid-feedback">{{ $message }}</div>
-                    @enderror
+                        <div>
+                            <label for="address" class="form-label">{{ __('cms.customers.address') }}</label>
+                            <textarea
+                                id="address"
+                                name="address"
+                                rows="4"
+                                maxlength="500"
+                                class="form-textarea @error('address') is-invalid @enderror"
+                                placeholder="{{ __('cms.customers.address_placeholder') }}"
+                            >{{ old('address') }}</textarea>
+                            @error('address')
+                                <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                            @enderror
+                        </div>
+                    </div>
                 </div>
+            </div>
 
-                <div class="col-md-4">
-                    <label for="status" class="form-label">{{ __('cms.customers.status') }}</label>
-                    <select name="status" id="status"
-                            class="form-select @error('status') is-invalid @enderror" required>
-                        <option value="active" {{ old('status', 'active') === 'active' ? 'selected' : '' }}>
-                            {{ __('cms.customers.active') }}</option>
-                        <option value="inactive" {{ old('status') === 'inactive' ? 'selected' : '' }}>
-                            {{ __('cms.customers.inactive') }}</option>
-                    </select>
-                    @error('status')
-                        <div class="invalid-feedback">{{ $message }}</div>
-                    @enderror
-                </div>
-
-                <div class="col-12 d-flex gap-2">
-                    <button type="submit" class="btn btn-success">{{ __('cms.customers.create_button') }}</button>
-                    <button type="button" class="btn btn-secondary"
-                            data-url="{{ route('admin.customers.index') }}">{{ __('cms.customers.cancel_button') }}</button>
-                </div>
-            </form>
-        </div>
-    </div>
+            <div class="flex flex-wrap justify-end gap-3">
+                <button type="submit" class="btn btn-primary">
+                    {{ __('cms.customers.create_button') }}
+                </button>
+                <x-admin.button-link href="{{ route('admin.customers.index') }}" class="btn-outline">
+                    {{ __('cms.customers.cancel_button') }}
+                </x-admin.button-link>
+            </div>
+        </form>
+    </x-admin.card>
 @endsection

--- a/resources/views/admin/customers/index.blade.php
+++ b/resources/views/admin/customers/index.blade.php
@@ -1,124 +1,179 @@
 @extends('admin.layouts.admin')
 
-@section('content')
-<div class="card mt-4">
-    <div class="card-header card-header-bg text-white d-flex justify-content-between align-items-center">
-        <h6 class="d-flex align-items-center mb-0 dt-heading">{{ __('cms.customers.customer_list') }}</h6>
-        <button type="button" class="btn btn-light btn-sm"
-                data-url="{{ route('admin.customers.create') }}">{{ __('cms.sidebar.customers.add_new') }}</button>
-    </div>
-    <div class="card-body">
-        <table id="customers-table" class="table table-bordered mt-4 dt-style">
-            <thead>
-                <tr>
-                    <th>{{ __('cms.customers.id') }}</th>
-                    <th>{{ __('cms.customers.name') }}</th>
-                    <th>{{ __('cms.customers.email') }}</th>
-                    <th>{{ __('cms.customers.phone') }}</th>
-                    <th>{{ __('cms.customers.address') }}</th>
-                    <th>{{ __('cms.customers.status') }}</th>
-                    <th>{{ __('cms.customers.actions') }}</th>
-                </tr>
-            </thead>
-        </table>
-    </div>
-</div>
+@php
+    $statusBadges = [
+        'active' => 'badge badge-success',
+        'inactive' => 'badge badge-danger',
+    ];
+@endphp
 
-<!-- Delete Modal -->
-<div class="modal fade" id="deleteCustomerModal" tabindex="-1" aria-labelledby="deleteCustomerModalLabel" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="deleteCustomerModalLabel">{{ __('cms.customers.confirm_delete_title') }}</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+@section('content')
+    <x-admin.page-header
+        :title="__('cms.customers.index_title')"
+        :description="__('cms.customers.index_description')"
+    >
+        <x-admin.button-link href="{{ route('admin.customers.create') }}" class="btn-primary">
+            {{ __('cms.customers.create_button_short') }}
+        </x-admin.button-link>
+    </x-admin.page-header>
+
+    <x-admin.card class="mt-6">
+        <div class="grid gap-6">
+            <form method="GET" action="{{ route('admin.customers.index') }}" class="grid gap-4 lg:grid-cols-[2fr,1fr,auto]">
+                <div>
+                    <label for="search" class="form-label">{{ __('cms.customers.search_label') }}</label>
+                    <input
+                        id="search"
+                        type="search"
+                        name="search"
+                        value="{{ $filters['search'] }}"
+                        placeholder="{{ __('cms.customers.search_placeholder') }}"
+                        class="form-control"
+                    >
+                </div>
+
+                <div>
+                    <label for="status" class="form-label">{{ __('cms.customers.filter_status_label') }}</label>
+                    <select id="status" name="status" class="form-select">
+                        @foreach ($statusOptions as $value => $label)
+                            <option value="{{ $value }}" @selected($filters['status'] === $value)>
+                                {{ $label }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+
+                <div class="flex items-end gap-3">
+                    <button type="submit" class="btn btn-primary">
+                        {{ __('cms.customers.apply_filters') }}
+                    </button>
+                    <a href="{{ route('admin.customers.index') }}" class="btn btn-outline">
+                        {{ __('cms.customers.reset_filters') }}
+                    </a>
+                </div>
+            </form>
+
+            <div class="grid gap-4 sm:grid-cols-3">
+                <div class="rounded-xl border border-gray-200 bg-white p-4">
+                    <p class="text-sm font-medium text-gray-500">{{ __('cms.customers.metric_total') }}</p>
+                    <p class="mt-2 text-2xl font-semibold text-gray-900">{{ number_format($customers->total()) }}</p>
+                    <p class="mt-1 text-xs text-gray-500">{{ __('cms.customers.metric_total_hint') }}</p>
+                </div>
+                <div class="rounded-xl border border-gray-200 bg-white p-4">
+                    <p class="text-sm font-medium text-gray-500">{{ __('cms.customers.metric_active') }}</p>
+                    <p class="mt-2 text-2xl font-semibold text-gray-900">{{ number_format($statusCounts['active']) }}</p>
+                    <p class="mt-1 text-xs text-gray-500">{{ __('cms.customers.metric_active_hint') }}</p>
+                </div>
+                <div class="rounded-xl border border-gray-200 bg-white p-4">
+                    <p class="text-sm font-medium text-gray-500">{{ __('cms.customers.metric_inactive') }}</p>
+                    <p class="mt-2 text-2xl font-semibold text-gray-900">{{ number_format($statusCounts['inactive']) }}</p>
+                    <p class="mt-1 text-xs text-gray-500">{{ __('cms.customers.metric_inactive_hint') }}</p>
+                </div>
             </div>
-            {{ __('cms.customers.confirm_delete_message') }}
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ __('cms.customers.cancel_button') }}</button>
-                <button type="button" class="btn btn-danger" id="confirmDeleteCustomer">{{ __('cms.customers.delete_button') }}</button>
+
+            <x-admin.table
+                data-customers-table
+                data-column-count="6"
+                data-empty-message="{{ __('cms.customers.empty_state_message') }}"
+                :columns="[
+                    __('cms.customers.id'),
+                    __('cms.customers.name'),
+                    __('cms.customers.email'),
+                    __('cms.customers.phone'),
+                    __('cms.customers.status'),
+                    __('cms.customers.actions'),
+                ]"
+            >
+                @forelse ($customers as $customer)
+                    <tr class="table-row">
+                        <td class="table-cell font-semibold">#{{ $customer->id }}</td>
+                        <td class="table-cell">
+                            <div class="flex flex-col">
+                                <span class="font-medium text-gray-900">{{ $customer->name }}</span>
+                                <span class="text-xs text-gray-500">{{ $customer->primary_address_line ?? __('cms.customers.not_available') }}</span>
+                            </div>
+                        </td>
+                        <td class="table-cell">
+                            <a href="mailto:{{ $customer->email }}" class="text-primary-600 hover:text-primary-700">
+                                {{ $customer->email }}
+                            </a>
+                        </td>
+                        <td class="table-cell">
+                            {{ $customer->phone ?: __('cms.customers.not_available') }}
+                        </td>
+                        <td class="table-cell">
+                            @php
+                                $status = $customer->status;
+                                $badgeClass = $statusBadges[$status] ?? 'badge';
+                                $statusLabel = $status === 'active'
+                                    ? __('cms.customers.active')
+                                    : __('cms.customers.inactive');
+                            @endphp
+                            <span class="{{ $badgeClass }}">{{ $statusLabel }}</span>
+                        </td>
+                        <td class="table-cell">
+                            <div class="flex flex-wrap gap-2">
+                                <a href="{{ route('admin.customers.show', $customer) }}" class="btn btn-sm btn-outline">
+                                    {{ __('cms.customers.view_button') }}
+                                </a>
+                                <button
+                                    type="button"
+                                    class="btn btn-sm btn-outline-danger"
+                                    data-customer-delete="{{ $customer->id }}"
+                                    data-customer-label="{{ $customer->name }}"
+                                >
+                                    {{ __('cms.customers.delete_button') }}
+                                </button>
+                            </div>
+                        </td>
+                    </tr>
+                @empty
+                    <tr data-customers-empty-row>
+                        <td colspan="6" class="table-cell py-6 text-center text-sm text-gray-500">
+                            {{ __('cms.customers.empty_state_message') }}
+                        </td>
+                    </tr>
+                @endforelse
+            </x-admin.table>
+
+            @if ($customers->hasPages())
+                <div>
+                    {{ $customers->links() }}
+                </div>
+            @endif
+        </div>
+    </x-admin.card>
+
+    <div
+        data-customer-delete-modal
+        data-delete-url="{{ route('admin.customers.destroy', ['customer' => '__CUSTOMER_ID__']) }}"
+        data-success-title="{{ __('cms.customers.success_title') }}"
+        data-success-message="{{ __('cms.customers.delete_success_message') }}"
+        data-error-title="{{ __('cms.customers.error_title') }}"
+        data-error-message="{{ __('cms.customers.delete_error_message') }}"
+        class="fixed inset-0 z-40 hidden"
+    >
+        <div class="absolute inset-0 bg-gray-900/60" data-dismiss-modal></div>
+        <div class="relative z-10 flex min-h-full items-center justify-center p-4">
+            <div class="w-full max-w-md overflow-hidden rounded-2xl bg-white shadow-xl">
+                <div class="border-b border-gray-200 px-6 py-4">
+                    <h2 class="text-base font-semibold text-gray-900">
+                        {{ __('cms.customers.confirm_delete_title') }}
+                    </h2>
+                </div>
+                <div class="px-6 py-5 space-y-2">
+                    <p class="text-sm text-gray-600">{{ __('cms.customers.confirm_delete_message') }}</p>
+                    <p class="text-sm font-semibold text-gray-900" data-customer-label></p>
+                </div>
+                <div class="flex items-center justify-end gap-3 border-t border-gray-200 bg-gray-50 px-6 py-4">
+                    <button type="button" class="btn btn-outline" data-dismiss-modal>
+                        {{ __('cms.customers.cancel_button') }}
+                    </button>
+                    <button type="button" class="btn btn-danger" data-confirm-delete>
+                        {{ __('cms.customers.delete_button') }}
+                    </button>
+                </div>
             </div>
         </div>
     </div>
-</div>
-@endsection
-
-@section('js')
-@php
-    $datatableLang = __('cms.datatables'); 
-@endphp
-
-<script>
-$(document).ready(function() {
-    $('#customers-table').DataTable({
-        processing: true,
-        serverSide: true,
-        ajax: {
-            url: "{{ route('admin.customers.data') }}",
-            type: "GET"
-        },
-        columns: [
-            { data: 'id', name: 'id' },
-            { data: 'name', name: 'name' },
-            { data: 'email', name: 'email' },
-            { data: 'phone', name: 'phone' },
-            { data: 'address', name: 'address' },
-            {
-                data: 'status',
-                name: 'status',
-                orderable: false,
-                searchable: false
-            },
-            {
-                data: 'action',
-                orderable: false,
-                searchable: false
-            }
-        ],
-        pageLength: 10,
-        language: @json($datatableLang)
-    });
-});
-
-let customerToDeleteId = null;
-
-$(document).on('click', '.btn-delete-customer', function() {
-    customerToDeleteId = $(this).data('id');
-    $('#deleteCustomerModal').modal('show');
-});
-
-$('#confirmDeleteCustomer').off('click').on('click', function() {
-    if (customerToDeleteId !== null) {
-        $.ajax({
-            url: '{{ route('admin.customers.destroy', ':id') }}'.replace(':id', customerToDeleteId),
-            method: 'DELETE',
-            data: {
-                _token: "{{ csrf_token() }}",
-            },
-            success: function(response) {
-                if (response.success) {
-                    $('#customers-table').DataTable().ajax.reload();
-                    toastr.error(response.message, "Deleted", {
-                        closeButton: true,
-                        progressBar: true,
-                        positionClass: "toast-top-right",
-                        timeOut: 5000
-                    });
-                    $('#deleteCustomerModal').modal('hide');
-                } else {
-                    toastr.error(response.message || 'Error deleting customer', "Error", {
-                        closeButton: true,
-                        progressBar: true,
-                        positionClass: "toast-top-right",
-                        timeOut: 5000
-                    });
-                }
-            },
-            error: function() {
-                toastr.error("Error deleting customer!", "Error");
-                $('#deleteCustomerModal').modal('hide');
-            }
-        });
-    }
-});
-</script>
 @endsection

--- a/tests/Feature/AdminCustomerManagementTest.php
+++ b/tests/Feature/AdminCustomerManagementTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Customer;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminCustomerManagementTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        app()->setLocale('en');
+        config(['app.locale' => 'en']);
+    }
+
+    public function test_admin_can_view_customer_index_with_filters(): void
+    {
+        $admin = User::factory()->create();
+        $matchingCustomer = Customer::factory()->create([
+            'name' => 'Alice Active',
+            'email' => 'alice@example.com',
+            'status' => 'active',
+        ]);
+        Customer::factory()->inactive()->create([
+            'name' => 'Ivan Idle',
+            'email' => 'ivan@example.com',
+        ]);
+
+        $this->actingAs($admin);
+
+        $response = $this->get(route('admin.customers.index', [
+            'search' => 'Alice',
+            'status' => 'active',
+        ]));
+
+        $response->assertOk();
+        $response->assertViewIs('admin.customers.index');
+        $response->assertSee('Alice Active');
+        $response->assertDontSee('Ivan Idle');
+        $response->assertSeeText(__('cms.customers.metric_active'));
+        $response->assertSeeText((string) $matchingCustomer->id);
+    }
+
+    public function test_admin_can_view_create_form(): void
+    {
+        $admin = User::factory()->create();
+        $this->actingAs($admin);
+
+        $response = $this->get(route('admin.customers.create'));
+
+        $response->assertOk();
+        $response->assertViewIs('admin.customers.create');
+        $response->assertSeeText(__('cms.customers.create_title'));
+        $response->assertSeeText(__('cms.customers.form_section_profile'));
+    }
+
+    public function test_admin_can_create_customer(): void
+    {
+        $admin = User::factory()->create();
+        $this->actingAs($admin);
+
+        $payload = [
+            'name' => 'Test Customer',
+            'email' => 'test.customer@example.com',
+            'password' => 'securePass123',
+            'phone' => '+1 555 0200',
+            'address' => '100 Demo Street, Test City',
+            'status' => 'active',
+        ];
+
+        $response = $this->post(route('admin.customers.store'), $payload);
+
+        $response->assertRedirect(route('admin.customers.index'));
+        $this->assertDatabaseHas('customers', [
+            'email' => 'test.customer@example.com',
+            'status' => 'active',
+        ]);
+    }
+
+    public function test_customer_email_must_be_unique(): void
+    {
+        $admin = User::factory()->create();
+        $this->actingAs($admin);
+
+        Customer::factory()->create([
+            'email' => 'duplicate@example.com',
+        ]);
+
+        $payload = [
+            'name' => 'Another Customer',
+            'email' => 'duplicate@example.com',
+            'password' => 'securePass123',
+            'phone' => '+1 555 0201',
+            'address' => '200 Demo Street, Test City',
+            'status' => 'active',
+        ];
+
+        $response = $this
+            ->from(route('admin.customers.create'))
+            ->post(route('admin.customers.store'), $payload);
+
+        $response->assertRedirect(route('admin.customers.create'));
+        $response->assertSessionHasErrors('email');
+    }
+}


### PR DESCRIPTION
## Summary
- modernize the admin customer index with Tailwind components, filters, metrics, and an AJAX-powered delete modal
- rebuild the customer creation form with clearer sections, reusable styling, and translation keys
- introduce form requests, richer demo seeding, a customer delete script, and feature coverage for listing and storing customers

## Testing
- `php artisan test` *(fails: missing Composer dependencies due to GitHub rate limiting in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df12ff10e0832985ae7e087fedbcbf