### PR TITLE
Refactor admin coupons module with Tailwind UI and form requests

### DIFF
--- a/app/Http/Requests/Admin/CouponRequest.php
+++ b/app/Http/Requests/Admin/CouponRequest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Carbon\Carbon;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Validation\Rule;
+
+abstract class CouponRequest extends FormRequest
+{
+    protected ?Carbon $parsedExpiresAt = null;
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'code' => ['required', 'string', 'max:255', $this->codeRule()],
+            'discount' => ['required', 'numeric', 'min:0'],
+            'type' => ['required', Rule::in(['percentage', 'fixed'])],
+            'expires_at' => ['nullable', 'date'],
+        ];
+    }
+
+    abstract protected function codeRule(): Rule;
+
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($validator) {
+            $type = $this->input('type');
+            $discount = $this->input('discount');
+
+            if ($type === 'percentage' && is_numeric($discount) && (float) $discount > 100) {
+                $validator->errors()->add('discount', __('cms.coupons.errors.percentage_limit'));
+            }
+        });
+    }
+
+    protected function passedValidation(): void
+    {
+        $expiresAt = $this->input('expires_at');
+
+        if (! $expiresAt) {
+            $this->parsedExpiresAt = null;
+
+            return;
+        }
+
+        try {
+            $this->parsedExpiresAt = Carbon::parse($expiresAt);
+        } catch (\Throwable $throwable) {
+            Log::warning('Invalid coupon expiry provided', [
+                'value' => $expiresAt,
+                'error' => $throwable->getMessage(),
+            ]);
+
+            $this->parsedExpiresAt = null;
+        }
+    }
+
+    public function validatedData(): array
+    {
+        $data = $this->validated();
+        $data['expires_at'] = $this->parsedExpiresAt;
+
+        return $data;
+    }
+}

--- a/app/Http/Requests/Admin/StoreCouponRequest.php
+++ b/app/Http/Requests/Admin/StoreCouponRequest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Validation\Rule;
+
+class StoreCouponRequest extends CouponRequest
+{
+    protected function codeRule(): Rule
+    {
+        return Rule::unique('coupons', 'code');
+    }
+}

--- a/app/Http/Requests/Admin/UpdateCouponRequest.php
+++ b/app/Http/Requests/Admin/UpdateCouponRequest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Requests\Admin;
+
+use Illuminate\Validation\Rule;
+
+class UpdateCouponRequest extends CouponRequest
+{
+    protected function codeRule(): Rule
+    {
+        $coupon = $this->route('coupon');
+
+        return Rule::unique('coupons', 'code')->ignore($coupon?->getKey());
+    }
+}

--- a/lang/en/cms.php
+++ b/lang/en/cms.php
@@ -1150,16 +1150,24 @@ return [
 
     'coupons' => [
         'heading' => 'Coupons',
+        'list_description' => 'Monitor discount codes, their status, and expiry at a glance.',
         'add_new' => 'Add Coupon',
         'id' => 'ID',
+        'column_coupon' => 'Coupon',
         'code' => 'Code',
         'discount' => 'Discount',
         'type' => 'Type',
+        'status' => 'Status',
         'expires_at' => 'Expires At',
+        'created_at' => 'Created',
         'action' => 'Action',
+        'table_title' => 'Coupon overview',
+        'empty' => 'No coupons found.',
 
         'create_title' => 'Create Coupon',
         'edit_title' => 'Edit Coupon',
+        'form_title' => 'Coupon details',
+        'form_description' => 'Define coupon codes, discount amounts, and availability windows.',
         'back_to_list' => 'Back to Coupons',
         'save' => 'Save Coupon',
         'update' => 'Update Coupon',
@@ -1168,6 +1176,7 @@ return [
         'delete_confirm_message' => 'Are you sure you want to delete this coupon?',
         'delete_cancel' => 'Cancel',
         'delete_button' => 'Delete',
+        'modal_coupon_label' => 'Coupon code: :code',
 
         'discount_hint' => 'For percentage coupons the value must be between 0 and 100.',
         'expiry_hint' => 'Leave empty to keep the coupon active indefinitely or set a past date to expire immediately.',
@@ -1182,6 +1191,23 @@ return [
         'type_labels' => [
             'percentage' => 'Percentage',
             'fixed' => 'Fixed Amount',
+        ],
+
+        'status_labels' => [
+            'active' => 'Active',
+            'expired' => 'Expired',
+        ],
+
+        'filters' => [
+            'all' => 'All coupons',
+            'active' => 'Active',
+            'expired' => 'Expired',
+        ],
+
+        'stats' => [
+            'total' => 'Total coupons',
+            'active' => 'Active coupons',
+            'expired' => 'Expired coupons',
         ],
 
         'errors' => [

--- a/resources/js/admin/coupons/index.js
+++ b/resources/js/admin/coupons/index.js
@@ -1,0 +1,203 @@
+import axios from 'axios';
+
+const getCsrfToken = () => {
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    return meta ? meta.getAttribute('content') : '';
+};
+
+const showToast = (type, message, title) => {
+    if (!window.toastr) {
+        return;
+    }
+
+    const toast = window.toastr[type] ?? window.toastr.info;
+    toast(message, title, {
+        closeButton: true,
+        progressBar: true,
+        positionClass: 'toast-top-right',
+        timeOut: 5000,
+    });
+};
+
+const formatNumber = (value) => {
+    const numericValue = Number(value);
+
+    if (Number.isNaN(numericValue)) {
+        return '0';
+    }
+
+    return new Intl.NumberFormat().format(numericValue);
+};
+
+const updateStats = (stats) => {
+    if (!stats || typeof stats !== 'object') {
+        return;
+    }
+
+    Object.entries(stats).forEach(([key, value]) => {
+        const element = document.querySelector(`[data-coupons-stat="${key}"]`);
+        if (!element) {
+            return;
+        }
+
+        element.textContent = formatNumber(value);
+    });
+};
+
+const createEmptyRow = (tableElement) => {
+    const tableBody = tableElement?.querySelector('tbody');
+    if (!tableBody) {
+        return null;
+    }
+
+    const emptyMessage = tableElement.dataset.emptyMessage ?? '';
+    const columnCountValue = tableElement.dataset.columnCount ?? '1';
+    const columnCount = Number.parseInt(columnCountValue, 10);
+
+    const emptyRow = document.createElement('tr');
+    emptyRow.dataset.couponsEmptyRow = '';
+
+    const emptyCell = document.createElement('td');
+    emptyCell.colSpan = Number.isNaN(columnCount) ? 1 : columnCount;
+    emptyCell.className = 'table-cell py-6 text-center text-sm text-gray-500';
+    emptyCell.textContent = emptyMessage;
+
+    emptyRow.appendChild(emptyCell);
+
+    return emptyRow;
+};
+
+const removeCouponRow = (couponId, tableElement) => {
+    if (!tableElement) {
+        window.location.reload();
+        return;
+    }
+
+    const deleteButton = document.querySelector(`[data-coupon-delete="${couponId}"]`);
+    const row = deleteButton?.closest('tr') ?? tableElement.querySelector(`[data-coupon-row="${couponId}"]`);
+    const tableBody = row?.parentElement ?? tableElement.querySelector('tbody');
+
+    if (!row || !tableBody) {
+        window.location.reload();
+        return;
+    }
+
+    row.remove();
+
+    if (tableBody.children.length > 0) {
+        return;
+    }
+
+    const emptyRow = createEmptyRow(tableElement);
+    if (emptyRow) {
+        tableBody.appendChild(emptyRow);
+    }
+};
+
+const initializeCouponPage = () => {
+    const modal = document.querySelector('[data-coupons-delete-modal]');
+    const tableElement = document.querySelector('[data-coupons-table]');
+
+    if (!modal) {
+        return;
+    }
+
+    const confirmButton = modal.querySelector('[data-confirm-delete]');
+    const cancelTriggers = modal.querySelectorAll('[data-dismiss-modal]');
+    const couponLabel = modal.querySelector('[data-coupon-label]');
+
+    const deleteUrlTemplate = modal.dataset.deleteUrl;
+    const successTitle = modal.dataset.successTitle;
+    const successMessage = modal.dataset.successMessage;
+    const errorTitle = modal.dataset.errorTitle;
+    const errorMessage = modal.dataset.errorMessage;
+
+    let currentCouponId = null;
+
+    const hideModal = () => {
+        modal.classList.add('hidden');
+        currentCouponId = null;
+
+        if (couponLabel) {
+            couponLabel.textContent = '';
+        }
+
+        if (confirmButton) {
+            confirmButton.disabled = false;
+        }
+    };
+
+    const showModal = () => {
+        modal.classList.remove('hidden');
+    };
+
+    cancelTriggers.forEach((trigger) => {
+        trigger.addEventListener('click', hideModal);
+    });
+
+    modal.addEventListener('click', (event) => {
+        if (event.target === modal) {
+            hideModal();
+        }
+    });
+
+    window.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && !modal.classList.contains('hidden')) {
+            hideModal();
+        }
+    });
+
+    document.addEventListener('click', (event) => {
+        const deleteButton = event.target.closest?.('[data-coupon-delete]');
+        if (!deleteButton) {
+            return;
+        }
+
+        event.preventDefault();
+
+        currentCouponId = deleteButton.dataset.couponDelete ?? null;
+
+        if (couponLabel) {
+            couponLabel.textContent = deleteButton.dataset.couponLabel ?? '';
+        }
+
+        showModal();
+    });
+
+    if (!confirmButton || !deleteUrlTemplate) {
+        return;
+    }
+
+    confirmButton.addEventListener('click', async () => {
+        if (!currentCouponId) {
+            return;
+        }
+
+        confirmButton.disabled = true;
+
+        const csrfToken = getCsrfToken();
+        const deleteUrl = deleteUrlTemplate.replace('__COUPON_ID__', currentCouponId);
+
+        try {
+            const response = await axios.delete(deleteUrl, {
+                data: { _token: csrfToken },
+            });
+
+            if (response.data?.success) {
+                removeCouponRow(currentCouponId, tableElement);
+                updateStats(response.data.stats);
+                showToast('success', response.data.message ?? successMessage, successTitle);
+                hideModal();
+            } else {
+                showToast('error', response.data?.message ?? errorMessage, errorTitle);
+            }
+        } catch (error) {
+            console.error('Failed to delete coupon', error);
+            showToast('error', errorMessage, errorTitle);
+        } finally {
+            confirmButton.disabled = false;
+        }
+    });
+};
+
+document.addEventListener('DOMContentLoaded', initializeCouponPage);

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,6 +1,7 @@
 import './bootstrap';
 import './admin/sidebar';
 import './admin/orders/index';
+import './admin/coupons/index';
 
 document.addEventListener('click', function (event) {
     const target = event.target;

--- a/resources/views/admin/coupons/create.blade.php
+++ b/resources/views/admin/coupons/create.blade.php
@@ -1,19 +1,21 @@
 @extends('admin.layouts.admin')
 
 @section('content')
-    <div class="card mt-4">
-        <div class="card-header card-header-bg text-white d-flex justify-content-between align-items-center">
-            <h6 class="mb-0">{{ __('cms.coupons.create_title') }}</h6>
-            <a href="{{ route('admin.coupons.index') }}" class="btn btn-light btn-sm">
-                {{ __('cms.coupons.back_to_list') }}
-            </a>
-        </div>
-        <div class="card-body">
-            @include('admin.coupons.partials.form', [
-                'action' => route('admin.coupons.store'),
-                'method' => 'POST',
-                'submitLabel' => __('cms.coupons.save'),
-            ])
-        </div>
-    </div>
+    <x-admin.page-header
+        :title="__('cms.coupons.create_title')"
+        :description="__('cms.coupons.form_description')"
+    >
+        <x-admin.button-link href="{{ route('admin.coupons.index') }}" class="btn-outline btn-sm">
+            {{ __('cms.coupons.back_to_list') }}
+        </x-admin.button-link>
+    </x-admin.page-header>
+
+    <x-admin.card class="mt-6" :title="__('cms.coupons.form_title')">
+        @include('admin.coupons.partials.form', [
+            'action' => route('admin.coupons.store'),
+            'method' => 'POST',
+            'submitLabel' => __('cms.coupons.save'),
+            'cancelUrl' => route('admin.coupons.index'),
+        ])
+    </x-admin.card>
 @endsection

--- a/resources/views/admin/coupons/edit.blade.php
+++ b/resources/views/admin/coupons/edit.blade.php
@@ -1,20 +1,22 @@
 @extends('admin.layouts.admin')
 
 @section('content')
-    <div class="card mt-4">
-        <div class="card-header card-header-bg text-white d-flex justify-content-between align-items-center">
-            <h6 class="mb-0">{{ __('cms.coupons.edit_title') }}</h6>
-            <a href="{{ route('admin.coupons.index') }}" class="btn btn-light btn-sm">
-                {{ __('cms.coupons.back_to_list') }}
-            </a>
-        </div>
-        <div class="card-body">
-            @include('admin.coupons.partials.form', [
-                'action' => route('admin.coupons.update', $coupon->id),
-                'method' => 'PUT',
-                'submitLabel' => __('cms.coupons.update'),
-                'coupon' => $coupon,
-            ])
-        </div>
-    </div>
+    <x-admin.page-header
+        :title="__('cms.coupons.edit_title')"
+        :description="__('cms.coupons.form_description')"
+    >
+        <x-admin.button-link href="{{ route('admin.coupons.index') }}" class="btn-outline btn-sm">
+            {{ __('cms.coupons.back_to_list') }}
+        </x-admin.button-link>
+    </x-admin.page-header>
+
+    <x-admin.card class="mt-6" :title="__('cms.coupons.form_title')">
+        @include('admin.coupons.partials.form', [
+            'action' => route('admin.coupons.update', $coupon),
+            'method' => 'PUT',
+            'submitLabel' => __('cms.coupons.update'),
+            'cancelUrl' => route('admin.coupons.index'),
+            'coupon' => $coupon,
+        ])
+    </x-admin.card>
 @endsection

--- a/resources/views/admin/coupons/index.blade.php
+++ b/resources/views/admin/coupons/index.blade.php
@@ -1,42 +1,179 @@
 @extends('admin.layouts.admin')
 
+@php
+    $deleteTemplate = route('admin.coupons.destroy', ['coupon' => '__COUPON_ID__']);
+    $couponStats = [
+        'total' => $stats['total'] ?? 0,
+        'active' => $stats['active'] ?? 0,
+        'expired' => $stats['expired'] ?? 0,
+    ];
+@endphp
+
 @section('content')
-    <div class="card mt-4">
-        <div class="card-header card-header-bg text-white d-flex justify-content-between align-items-center">
-            <h6 class="mb-0">{{ __('cms.coupons.heading') }}</h6>
-            <a href="{{ route('admin.coupons.create') }}" class="btn btn-light btn-sm">
-                {{ __('cms.coupons.add_new') }}
-            </a>
+    <x-admin.page-header
+        :title="__('cms.coupons.heading')"
+        :description="__('cms.coupons.list_description')"
+    >
+        <x-admin.button-link href="{{ route('admin.coupons.create') }}" class="btn-primary btn-sm">
+            {{ __('cms.coupons.add_new') }}
+        </x-admin.button-link>
+    </x-admin.page-header>
+
+    <div class="mt-6 grid gap-4 sm:grid-cols-3">
+        <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <p class="text-xs font-medium uppercase tracking-wide text-gray-500">{{ __('cms.coupons.stats.total') }}</p>
+            <p class="mt-2 text-2xl font-semibold text-gray-900" data-coupons-stat="total">
+                {{ number_format($couponStats['total']) }}
+            </p>
         </div>
-        <div class="card-body">
-            <table id="coupons-table" class="table table-bordered mt-4 w-100">
-                <thead>
-                    <tr>
-                        <th>{{ __('cms.coupons.id') }}</th>
-                        <th>{{ __('cms.coupons.code') }}</th>
-                        <th>{{ __('cms.coupons.discount') }}</th>
-                        <th>{{ __('cms.coupons.type') }}</th>
-                        <th>{{ __('cms.coupons.expires_at') }}</th>
-                        <th>{{ __('cms.coupons.action') }}</th>
-                    </tr>
-                </thead>
-            </table>
+        <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <p class="text-xs font-medium uppercase tracking-wide text-gray-500">{{ __('cms.coupons.stats.active') }}</p>
+            <p class="mt-2 text-2xl font-semibold text-gray-900" data-coupons-stat="active">
+                {{ number_format($couponStats['active']) }}
+            </p>
+        </div>
+        <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+            <p class="text-xs font-medium uppercase tracking-wide text-gray-500">{{ __('cms.coupons.stats.expired') }}</p>
+            <p class="mt-2 text-2xl font-semibold text-gray-900" data-coupons-stat="expired">
+                {{ number_format($couponStats['expired']) }}
+            </p>
         </div>
     </div>
 
-    <div class="modal fade" id="deleteCouponModal" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">{{ __('cms.coupons.delete_confirm_title') }}</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+    <x-admin.card class="mt-6" :title="__('cms.coupons.table_title')">
+        <div class="flex flex-wrap items-center gap-2 mb-4">
+            @foreach ($statusFilters as $value => $label)
+                @php
+                    $isActive = $currentStatus === $value;
+                    $filterUrl = $value === ''
+                        ? route('admin.coupons.index')
+                        : route('admin.coupons.index', ['status' => $value]);
+                @endphp
+                <a
+                    href="{{ $filterUrl }}"
+                    class="btn btn-sm {{ $isActive ? 'btn-primary' : 'btn-outline' }}"
+                >
+                    {{ $label }}
+                </a>
+            @endforeach
+        </div>
+
+        <x-admin.table
+            data-coupons-table
+            data-column-count="6"
+            data-empty-message="{{ __('cms.coupons.empty') }}"
+            :columns="[
+                __('cms.coupons.column_coupon'),
+                __('cms.coupons.discount'),
+                __('cms.coupons.status'),
+                __('cms.coupons.expires_at'),
+                __('cms.coupons.created_at'),
+                __('cms.coupons.action'),
+            ]"
+        >
+            @forelse ($coupons as $coupon)
+                @php
+                    $isExpired = $coupon->isExpired();
+                    $discountValue = rtrim(rtrim(number_format($coupon->discount, 2), '0'), '.');
+                    $formattedDiscount = $coupon->type === 'percentage'
+                        ? $discountValue.'%'
+                        : $discountValue;
+                @endphp
+                <tr class="table-row" data-coupon-row="{{ $coupon->id }}">
+                    <td class="table-cell">
+                        <div class="flex flex-col">
+                            <span class="text-sm font-semibold text-gray-900">{{ $coupon->code }}</span>
+                            <span class="text-xs text-gray-500">#{{ $coupon->id }}</span>
+                        </div>
+                    </td>
+                    <td class="table-cell">
+                        <div class="flex flex-col">
+                            <span class="text-sm font-semibold text-gray-900">{{ $formattedDiscount }}</span>
+                            <span class="text-xs text-gray-500">{{ __('cms.coupons.type_labels.'.$coupon->type) }}</span>
+                        </div>
+                    </td>
+                    <td class="table-cell">
+                        <span class="badge {{ $isExpired ? 'badge-danger' : 'badge-success' }}">
+                            {{ $isExpired ? __('cms.coupons.status_labels.expired') : __('cms.coupons.status_labels.active') }}
+                        </span>
+                    </td>
+                    <td class="table-cell">
+                        @if ($coupon->expires_at)
+                            <div class="flex flex-col">
+                                <span class="text-sm text-gray-900">{{ $coupon->expires_at->format('M d, Y H:i') }}</span>
+                                <span class="text-xs text-gray-500">{{ $coupon->expires_at->diffForHumans() }}</span>
+                            </div>
+                        @else
+                            <span class="text-sm text-gray-500">{{ __('cms.coupons.no_expiry') }}</span>
+                        @endif
+                    </td>
+                    <td class="table-cell">
+                        <div class="flex flex-col">
+                            <span class="text-sm text-gray-900">{{ optional($coupon->created_at)->format('M d, Y') ?? '—' }}</span>
+                            @if ($coupon->created_at)
+                                <span class="text-xs text-gray-500">{{ $coupon->created_at->diffForHumans() }}</span>
+                            @endif
+                        </div>
+                    </td>
+                    <td class="table-cell">
+                        <div class="flex flex-wrap items-center gap-2">
+                            <x-admin.button-link
+                                href="{{ route('admin.coupons.edit', $coupon) }}"
+                                class="btn-outline btn-sm"
+                            >
+                                {{ __('cms.coupons.edit_title') }}
+                            </x-admin.button-link>
+                            <button
+                                type="button"
+                                class="btn btn-outline-danger btn-sm"
+                                data-coupon-delete="{{ $coupon->id }}"
+                                data-coupon-label="{{ __('cms.coupons.modal_coupon_label', ['code' => $coupon->code]) }}"
+                            >
+                                {{ __('cms.coupons.delete_button') }}
+                            </button>
+                        </div>
+                    </td>
+                </tr>
+            @empty
+                <tr data-coupons-empty-row>
+                    <td colspan="6" class="table-cell py-6 text-center text-sm text-gray-500">
+                        {{ __('cms.coupons.empty') }}
+                    </td>
+                </tr>
+            @endforelse
+        </x-admin.table>
+
+        @if ($coupons->hasPages())
+            <div class="mt-4">
+                {{ $coupons->onEachSide(1)->links() }}
+            </div>
+        @endif
+    </x-admin.card>
+
+    <div
+        data-coupons-delete-modal
+        data-delete-url="{{ $deleteTemplate }}"
+        data-success-title="{{ __('cms.notifications.success') }}"
+        data-success-message="{{ __('cms.coupons.deleted') }}"
+        data-error-title="{{ __('cms.notifications.error') }}"
+        data-error-message="{{ __('cms.coupons.errors.delete_failed') }}"
+        class="fixed inset-0 z-50 hidden"
+    >
+        <div class="absolute inset-0 bg-gray-900/50" data-dismiss-modal></div>
+        <div class="relative z-10 flex min-h-full items-center justify-center p-4">
+            <div class="w-full max-w-md overflow-hidden rounded-2xl bg-white shadow-xl">
+                <div class="border-b border-gray-200 px-6 py-4">
+                    <h2 class="text-base font-semibold text-gray-900">{{ __('cms.coupons.delete_confirm_title') }}</h2>
                 </div>
-                <div class="modal-body">{{ __('cms.coupons.delete_confirm_message') }}</div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">
+                <div class="space-y-2 px-6 py-5">
+                    <p class="text-sm text-gray-600">{{ __('cms.coupons.delete_confirm_message') }}</p>
+                    <p class="text-sm font-semibold text-gray-900" data-coupon-label></p>
+                </div>
+                <div class="flex items-center justify-end gap-3 border-t border-gray-200 bg-gray-50 px-6 py-4">
+                    <button type="button" class="btn btn-outline" data-dismiss-modal>
                         {{ __('cms.coupons.delete_cancel') }}
                     </button>
-                    <button type="button" class="btn btn-danger" id="confirmDeleteCoupon">
+                    <button type="button" class="btn btn-danger" data-confirm-delete>
                         {{ __('cms.coupons.delete_button') }}
                     </button>
                 </div>
@@ -44,109 +181,3 @@
         </div>
     </div>
 @endsection
-
-@php($datatableLang = __('cms.datatables'))
-
-@push('scripts')
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const deleteModalElement = document.getElementById('deleteCouponModal');
-            const deleteModal = new bootstrap.Modal(deleteModalElement);
-            let couponToDeleteId = null;
-
-            const table = $('#coupons-table').DataTable({
-                processing: true,
-                serverSide: true,
-                ajax: {
-                    url: "{{ route('admin.coupons.data') }}",
-                    type: 'POST',
-                    data: function (d) {
-                        d._token = "{{ csrf_token() }}";
-                    },
-                },
-                columns: [
-                    { data: 'id', name: 'id' },
-                    { data: 'code', name: 'code' },
-                    { data: 'discount', name: 'discount', orderable: false, searchable: false },
-                    { data: 'type', name: 'type' },
-                    { data: 'expires_at', name: 'expires_at', orderable: false, searchable: false },
-                    { data: 'action', name: 'action', orderable: false, searchable: false },
-                ],
-                pageLength: 10,
-                language: @json($datatableLang),
-            });
-
-            const toastDefaults = {
-                closeButton: true,
-                progressBar: true,
-                positionClass: 'toast-top-right',
-            };
-
-            const hideModal = () => {
-                deleteModal.hide();
-                couponToDeleteId = null;
-            };
-
-            $(document).on('click', '.btn-edit-coupon', function () {
-                const url = $(this).data('url');
-
-                if (url) {
-                    window.location.href = url;
-                }
-            });
-
-            $(document).on('click', '.btn-delete-coupon', function () {
-                couponToDeleteId = $(this).data('id');
-                deleteModal.show();
-            });
-
-            deleteModalElement.addEventListener('hidden.bs.modal', () => {
-                couponToDeleteId = null;
-            });
-
-            document.getElementById('confirmDeleteCoupon').addEventListener('click', () => {
-                if (!couponToDeleteId) {
-                    return;
-                }
-
-                $.ajax({
-                    url: '{{ route('admin.coupons.destroy', ':id') }}'.replace(':id', couponToDeleteId),
-                    type: 'DELETE',
-                    data: {
-                        _token: "{{ csrf_token() }}",
-                    },
-                    success: function (response) {
-                        const message = response.message || '{{ __('cms.coupons.deleted') }}';
-
-                        if (response.success) {
-                            table.ajax.reload(null, false);
-                            toastr.success(message, "{{ __('cms.coupons.success') }}", {
-                                ...toastDefaults,
-                                timeOut: 4000,
-                            });
-                        } else {
-                            toastr.error(message, "{{ __('cms.coupons.error_title') }}", {
-                                ...toastDefaults,
-                                timeOut: 5000,
-                            });
-                        }
-
-                        hideModal();
-                    },
-                    error: function () {
-                        toastr.error(
-                            '{{ __('cms.coupons.errors.delete_failed') }}',
-                            "{{ __('cms.coupons.error_title') }}",
-                            {
-                                ...toastDefaults,
-                                timeOut: 5000,
-                            }
-                        );
-
-                        hideModal();
-                    },
-                });
-            });
-        });
-    </script>
-@endpush

--- a/routes/web.php
+++ b/routes/web.php
@@ -91,7 +91,6 @@ Route::prefix('admin')->name('admin.')->group(function () {
 
     /* Coupons */
     Route::resource('coupons', CouponController::class);
-    Route::post('coupons/data', [CouponController::class, 'getData'])->name('coupons.data');
 
     /* Product Variants */
     Route::resource('product_variants', ProductVariantController::class);


### PR DESCRIPTION
## Summary
- replace the coupons index with a Tailwind-based layout that shows quick stats, filters, and inline actions
- move coupon validation into dedicated form requests and enhance the controller with status filtering plus stat responses
- add modular JavaScript for the delete modal and refresh translations to cover the new interface copy

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df12c7696c832994897f725efacaee