### PR TITLE
Refine site settings management and propagate branding data

### DIFF
--- a/app/Http/Controllers/Admin/SiteSettingController.php
+++ b/app/Http/Controllers/Admin/SiteSettingController.php
@@ -6,6 +6,9 @@ use App\Http\Controllers\Controller;
 use App\Models\SiteSetting;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Illuminate\View\View;
 
 class SiteSettingController extends Controller
@@ -29,18 +32,38 @@ class SiteSettingController extends Controller
         $validated = $request->validate([
             'site_name' => ['required', 'string', 'max:255'],
             'tagline' => ['nullable', 'string', 'max:255'],
+            'top_bar_message' => ['nullable', 'string', 'max:255'],
             'meta_title' => ['nullable', 'string', 'max:255'],
             'meta_description' => ['nullable', 'string'],
             'meta_keywords' => ['nullable', 'string'],
-            'contact_email' => ['nullable', 'email'],
-            'contact_phone' => ['nullable', 'string', 'max:20'],
+            'contact_email' => ['nullable', 'email', 'max:255'],
+            'contact_phone' => ['nullable', 'string', 'max:30'],
             'address' => ['nullable', 'string'],
             'footer_text' => ['nullable', 'string'],
+            'facebook_url' => ['nullable', 'url', 'max:255'],
+            'instagram_url' => ['nullable', 'url', 'max:255'],
+            'twitter_url' => ['nullable', 'url', 'max:255'],
+            'linkedin_url' => ['nullable', 'url', 'max:255'],
+            'logo' => ['nullable', 'image', 'mimes:jpg,jpeg,png,svg', 'max:2048'],
+            'favicon' => ['nullable', 'image', 'mimes:jpg,jpeg,png,ico', 'max:512'],
         ]);
 
         $settings = $this->getSiteSettings();
         $settings->fill($validated);
+
+        if ($request->hasFile('logo')) {
+            $this->deleteExistingFile($settings->logo);
+            $settings->logo = $request->file('logo')->store('site-settings', 'public');
+        }
+
+        if ($request->hasFile('favicon')) {
+            $this->deleteExistingFile($settings->favicon);
+            $settings->favicon = $request->file('favicon')->store('site-settings', 'public');
+        }
+
         $settings->save();
+
+        Cache::forget('site_settings');
 
         return redirect()
             ->route('admin.site-settings.index')
@@ -50,5 +73,20 @@ class SiteSettingController extends Controller
     private function getSiteSettings(): SiteSetting
     {
         return SiteSetting::firstOrNew();
+    }
+
+    private function deleteExistingFile(?string $path): void
+    {
+        if (! $path) {
+            return;
+        }
+
+        if (Str::startsWith($path, ['http://', 'https://', 'assets/', 'images/', '/'])) {
+            return;
+        }
+
+        if (Storage::disk('public')->exists($path)) {
+            Storage::disk('public')->delete($path);
+        }
     }
 }

--- a/app/Models/SiteSetting.php
+++ b/app/Models/SiteSetting.php
@@ -4,6 +4,8 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 
 class SiteSetting extends Model
 {
@@ -16,13 +18,20 @@ class SiteSetting extends Model
     protected $fillable = [
         'site_name',
         'tagline',
+        'top_bar_message',
         'meta_title',
         'meta_description',
         'meta_keywords',
+        'logo',
+        'favicon',
         'contact_email',
         'contact_phone',
         'address',
         'footer_text',
+        'facebook_url',
+        'instagram_url',
+        'twitter_url',
+        'linkedin_url',
     ];
 
     // The attributes that should be cast to native types
@@ -31,5 +40,39 @@ class SiteSetting extends Model
         'updated_at' => 'datetime',
     ];
 
-    // Optional: You may want to include any relationships (e.g., translations, if necessary)
+    protected $appends = [
+        'logo_url',
+        'favicon_url',
+    ];
+
+    public function getLogoUrlAttribute(): ?string
+    {
+        return $this->resolveMediaUrl($this->logo);
+    }
+
+    public function getFaviconUrlAttribute(): ?string
+    {
+        return $this->resolveMediaUrl($this->favicon);
+    }
+
+    protected function resolveMediaUrl(?string $path): ?string
+    {
+        if (! $path) {
+            return null;
+        }
+
+        if (Str::startsWith($path, ['http://', 'https://'])) {
+            return $path;
+        }
+
+        if (Str::startsWith($path, ['assets/', 'images/', '/'])) {
+            return asset(ltrim($path, '/'));
+        }
+
+        if (Storage::disk('public')->exists($path)) {
+            return Storage::disk('public')->url($path);
+        }
+
+        return asset($path);
+    }
 }

--- a/database/factories/SiteSettingFactory.php
+++ b/database/factories/SiteSettingFactory.php
@@ -17,13 +17,20 @@ class SiteSettingFactory extends Factory
         return [
             'site_name' => $this->faker->company(),
             'tagline' => $this->faker->catchPhrase(),
+            'top_bar_message' => $this->faker->sentence(8),
             'meta_title' => $this->faker->sentence(),
             'meta_description' => $this->faker->paragraph(),
             'meta_keywords' => implode(',', $this->faker->words(4)),
+            'logo' => 'assets/images/logo-main.svg',
+            'favicon' => 'favicon.ico',
             'contact_email' => $this->faker->companyEmail(),
             'contact_phone' => $this->faker->phoneNumber(),
             'address' => $this->faker->address(),
             'footer_text' => $this->faker->sentence(),
+            'facebook_url' => $this->faker->url(),
+            'instagram_url' => $this->faker->url(),
+            'twitter_url' => $this->faker->url(),
+            'linkedin_url' => $this->faker->url(),
         ];
     }
 }

--- a/database/migrations/2025_02_22_000000_add_branding_fields_to_site_settings_table.php
+++ b/database/migrations/2025_02_22_000000_add_branding_fields_to_site_settings_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\\Database\\Migrations\\Migration;
+use Illuminate\\Database\\Schema\\Blueprint;
+use Illuminate\\Support\\Facades\\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('site_settings', function (Blueprint $table) {
+            $table->string('top_bar_message')->nullable()->after('tagline');
+            $table->string('facebook_url')->nullable()->after('footer_text');
+            $table->string('instagram_url')->nullable()->after('facebook_url');
+            $table->string('twitter_url')->nullable()->after('instagram_url');
+            $table->string('linkedin_url')->nullable()->after('twitter_url');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('site_settings', function (Blueprint $table) {
+            $table->dropColumn([
+                'top_bar_message',
+                'facebook_url',
+                'instagram_url',
+                'twitter_url',
+                'linkedin_url',
+            ]);
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -16,6 +16,7 @@ class DatabaseSeeder extends Seeder
             LanguageSeeder::class,
             BannerSeeder::class,
             PageSeeder::class,
+            SiteSettingsSeeder::class,
             ProductVariantLocaleSeeder::class,
             CurrencySeeder::class,
             VendorSeeder::class,

--- a/database/seeders/DemoDataSeeder.php
+++ b/database/seeders/DemoDataSeeder.php
@@ -46,6 +46,7 @@ use App\Models\User;
 use App\Models\Wishlist;
 use Illuminate\Database\Seeder;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
@@ -89,7 +90,10 @@ class DemoDataSeeder extends Seeder
                 $shops->push($shop);
             }
 
-            SiteSetting::factory()->count(1)->create();
+            if (SiteSetting::query()->doesntExist()) {
+                SiteSetting::factory()->create();
+                Cache::forget('site_settings');
+            }
             StoreSetting::factory()->count(10)->create();
 
             $socialLinks = SocialMediaLink::factory()->count(4)->create();

--- a/database/seeders/SiteSettingsSeeder.php
+++ b/database/seeders/SiteSettingsSeeder.php
@@ -2,8 +2,9 @@
 
 namespace Database\Seeders;
 
+use App\Models\SiteSetting;
 use Illuminate\Database\Seeder;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Cache;
 
 class SiteSettingsSeeder extends Seeder
 {
@@ -14,20 +15,28 @@ class SiteSettingsSeeder extends Seeder
      */
     public function run()
     {
-        DB::table('site_settings')->insert([
-            'site_name' => 'My Awesome Laravel Site',
-            'tagline' => 'Building the future of web development',
-            'meta_title' => 'My Awesome Laravel Site - Home',
-            'meta_description' => 'Welcome to My Awesome Laravel Site, the place for all your web development needs.',
-            'meta_keywords' => 'laravel, web development, awesome site',
-            'logo' => 'path_to_logo.png',
-            'favicon' => 'favicon.ico',
-            'contact_email' => 'contact@myawesomelarsite.com',
-            'contact_phone' => '+1 234 567 890',
-            'address' => '123 Laravel St, Web City, Webland',
-            'footer_text' => '© 2025 My Awesome Laravel Site. All rights reserved.',
-            'created_at' => now(),
-            'updated_at' => now(),
-        ]);
+        SiteSetting::query()->updateOrCreate(
+            ['id' => 1],
+            [
+                'site_name' => 'Velstore Demo',
+                'tagline' => 'Modern commerce experiences for every brand.',
+                'top_bar_message' => 'Free shipping on orders over $50 | Support | Store Locator',
+                'meta_title' => 'Velstore Demo - Discover Products You Love',
+                'meta_description' => 'Explore Velstore demo shop for beautifully curated collections, powerful commerce features, and a seamless shopping experience.',
+                'meta_keywords' => 'velstore, ecommerce, demo shop, laravel commerce',
+                'logo' => 'assets/images/logo-main.svg',
+                'favicon' => 'favicon.ico',
+                'contact_email' => 'support@velstore-demo.test',
+                'contact_phone' => '+1 (555) 123-4567',
+                'address' => '123 Commerce Street, Suite 400, Innovation City',
+                'footer_text' => '© ' . now()->year . ' Velstore Demo. All rights reserved.',
+                'facebook_url' => 'https://www.facebook.com/velstoredemo',
+                'instagram_url' => 'https://www.instagram.com/velstoredemo',
+                'twitter_url' => 'https://x.com/velstoredemo',
+                'linkedin_url' => 'https://www.linkedin.com/company/velstoredemo',
+            ]
+        );
+
+        Cache::forget('site_settings');
     }
 }

--- a/resources/views/admin/site-settings/edit.blade.php
+++ b/resources/views/admin/site-settings/edit.blade.php
@@ -4,76 +4,121 @@
 
     <div class="card mt-4">
         <div class="card-header bg-primary text-white">
-            <h6>Edit Site Settings</h6>
+            <h6 class="mb-0">Edit Site Settings</h6>
         </div>
         <div class="card-body">
-
-            @if (session('success'))
-                <div class="alert alert-success">
-                    {{ session('success') }}
+            @if ($errors->any())
+                <div class="alert alert-danger">
+                    <ul class="mb-0">
+                        @foreach ($errors->all() as $error)
+                            <li>{{ $error }}</li>
+                        @endforeach
+                    </ul>
                 </div>
             @endif
 
-            <form action="{{ route('admin.site-settings.update') }}" method="POST">
+            <form action="{{ route('admin.site-settings.update') }}" method="POST" enctype="multipart/form-data">
                 @csrf
                 @method('PUT')
 
-                <!-- Site Name -->
-                <div class="form-group">
-                    <label for="site_name">Site Name</label>
-                    <input type="text" name="site_name" class="form-control" value="{{ old('site_name', $settings->site_name ?? '') }}" required>
+                <div class="row g-4">
+                    <div class="col-md-6">
+                        <h6 class="text-uppercase text-muted mb-3">Brand Identity</h6>
+                        <div class="mb-3">
+                            <label for="site_name" class="form-label">Site Name</label>
+                            <input type="text" name="site_name" id="site_name" class="form-control" value="{{ old('site_name', $settings->site_name ?? '') }}" required>
+                        </div>
+                        <div class="mb-3">
+                            <label for="tagline" class="form-label">Tagline</label>
+                            <input type="text" name="tagline" id="tagline" class="form-control" value="{{ old('tagline', $settings->tagline ?? '') }}">
+                        </div>
+                        <div class="mb-3">
+                            <label for="top_bar_message" class="form-label">Top Bar Message</label>
+                            <input type="text" name="top_bar_message" id="top_bar_message" class="form-control" value="{{ old('top_bar_message', $settings->top_bar_message ?? '') }}">
+                        </div>
+                        <div class="mb-3">
+                            <label for="logo" class="form-label">Logo</label>
+                            <input type="file" name="logo" id="logo" class="form-control">
+                            <small class="text-muted">Upload a square PNG, JPG, or SVG up to 2MB.</small>
+                            @if (!empty($settings?->logo_url))
+                                <div class="mt-2">
+                                    <img src="{{ $settings->logo_url }}" alt="Current logo" class="img-fluid" style="max-height: 80px;">
+                                </div>
+                            @endif
+                        </div>
+                        <div class="mb-3">
+                            <label for="favicon" class="form-label">Favicon</label>
+                            <input type="file" name="favicon" id="favicon" class="form-control">
+                            <small class="text-muted">PNG, JPG, or ICO up to 512KB.</small>
+                            @if (!empty($settings?->favicon_url))
+                                <div class="mt-2">
+                                    <img src="{{ $settings->favicon_url }}" alt="Current favicon" class="img-thumbnail" style="max-height: 48px; width: auto;">
+                                </div>
+                            @endif
+                        </div>
+                    </div>
+
+                    <div class="col-md-6">
+                        <h6 class="text-uppercase text-muted mb-3">SEO</h6>
+                        <div class="mb-3">
+                            <label for="meta_title" class="form-label">Meta Title</label>
+                            <input type="text" name="meta_title" id="meta_title" class="form-control" value="{{ old('meta_title', $settings->meta_title ?? '') }}">
+                        </div>
+                        <div class="mb-3">
+                            <label for="meta_description" class="form-label">Meta Description</label>
+                            <textarea name="meta_description" id="meta_description" class="form-control" rows="3">{{ old('meta_description', $settings->meta_description ?? '') }}</textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="meta_keywords" class="form-label">Meta Keywords</label>
+                            <input type="text" name="meta_keywords" id="meta_keywords" class="form-control" value="{{ old('meta_keywords', $settings->meta_keywords ?? '') }}">
+                            <small class="text-muted">Separate keywords with commas.</small>
+                        </div>
+
+                        <h6 class="text-uppercase text-muted mb-3 mt-4">Contact Details</h6>
+                        <div class="mb-3">
+                            <label for="contact_email" class="form-label">Contact Email</label>
+                            <input type="email" name="contact_email" id="contact_email" class="form-control" value="{{ old('contact_email', $settings->contact_email ?? '') }}">
+                        </div>
+                        <div class="mb-3">
+                            <label for="contact_phone" class="form-label">Contact Phone</label>
+                            <input type="text" name="contact_phone" id="contact_phone" class="form-control" value="{{ old('contact_phone', $settings->contact_phone ?? '') }}">
+                        </div>
+                        <div class="mb-3">
+                            <label for="address" class="form-label">Address</label>
+                            <textarea name="address" id="address" class="form-control" rows="2">{{ old('address', $settings->address ?? '') }}</textarea>
+                        </div>
+                        <div class="mb-3">
+                            <label for="footer_text" class="form-label">Footer Text</label>
+                            <textarea name="footer_text" id="footer_text" class="form-control" rows="3">{{ old('footer_text', $settings->footer_text ?? '') }}</textarea>
+                        </div>
+                    </div>
                 </div>
 
-                <!-- Tagline -->
-                <div class="form-group">
-                    <label for="tagline">Tagline</label>
-                    <input type="text" name="tagline" class="form-control" value="{{ old('tagline', $settings->tagline ?? '') }}">
+                <div class="row g-4 mt-1">
+                    <div class="col-12">
+                        <h6 class="text-uppercase text-muted mb-3">Social Profiles</h6>
+                    </div>
+                    <div class="col-md-6">
+                        <label for="facebook_url" class="form-label">Facebook</label>
+                        <input type="url" name="facebook_url" id="facebook_url" class="form-control" value="{{ old('facebook_url', $settings->facebook_url ?? '') }}" placeholder="https://facebook.com/your-page">
+                    </div>
+                    <div class="col-md-6">
+                        <label for="instagram_url" class="form-label">Instagram</label>
+                        <input type="url" name="instagram_url" id="instagram_url" class="form-control" value="{{ old('instagram_url', $settings->instagram_url ?? '') }}" placeholder="https://instagram.com/your-profile">
+                    </div>
+                    <div class="col-md-6">
+                        <label for="twitter_url" class="form-label">Twitter / X</label>
+                        <input type="url" name="twitter_url" id="twitter_url" class="form-control" value="{{ old('twitter_url', $settings->twitter_url ?? '') }}" placeholder="https://x.com/your-handle">
+                    </div>
+                    <div class="col-md-6">
+                        <label for="linkedin_url" class="form-label">LinkedIn</label>
+                        <input type="url" name="linkedin_url" id="linkedin_url" class="form-control" value="{{ old('linkedin_url', $settings->linkedin_url ?? '') }}" placeholder="https://www.linkedin.com/company/your-company">
+                    </div>
                 </div>
 
-                <!-- Meta Title -->
-                <div class="form-group">
-                    <label for="meta_title">Meta Title</label>
-                    <input type="text" name="meta_title" class="form-control" value="{{ old('meta_title', $settings->meta_title ?? '') }}">
+                <div class="d-flex justify-content-end mt-4">
+                    <button type="submit" class="btn btn-success">Update Settings</button>
                 </div>
-
-                <!-- Meta Description -->
-                <div class="form-group">
-                    <label for="meta_description">Meta Description</label>
-                    <textarea name="meta_description" class="form-control">{{ old('meta_description', $settings->meta_description ?? '') }}</textarea>
-                </div>
-
-                <!-- Meta Keywords -->
-                <div class="form-group">
-                    <label for="meta_keywords">Meta Keywords</label>
-                    <input type="text" name="meta_keywords" class="form-control" value="{{ old('meta_keywords', $settings->meta_keywords ?? '') }}">
-                </div>
-
-                <!-- Contact Email -->
-                <div class="form-group">
-                    <label for="contact_email">Contact Email</label>
-                    <input type="email" name="contact_email" class="form-control" value="{{ old('contact_email', $settings->contact_email ?? '') }}">
-                </div>
-
-                <!-- Contact Phone -->
-                <div class="form-group">
-                    <label for="contact_phone">Contact Phone</label>
-                    <input type="text" name="contact_phone" class="form-control" value="{{ old('contact_phone', $settings->contact_phone ?? '') }}">
-                </div>
-
-                <!-- Address -->
-                <div class="form-group">
-                    <label for="address">Address</label>
-                    <input type="text" name="address" class="form-control" value="{{ old('address', $settings->address ?? '') }}">
-                </div>
-
-                <!-- Footer Text -->
-                <div class="form-group">
-                    <label for="footer_text">Footer Text</label>
-                    <textarea name="footer_text" class="form-control">{{ old('footer_text', $settings->footer_text ?? '') }}</textarea>
-                </div>
-
-                <!-- Submit Button -->
-                <button type="submit" class="btn btn-success mt-3">Update Settings</button>
             </form>
         </div>
     </div>

--- a/resources/views/admin/site-settings/index.blade.php
+++ b/resources/views/admin/site-settings/index.blade.php
@@ -4,53 +4,95 @@
 
 @section('content')
     <div class="card mt-4">
-        <div class="card-header bg-primary text-white">
-            <h6>Site Settings</h6>
+        <div class="card-header bg-primary text-white d-flex justify-content-between align-items-center">
+            <h6 class="mb-0">Site Settings</h6>
+            <a href="{{ route('admin.site-settings.edit') }}" class="btn btn-light btn-sm text-primary">Edit Settings</a>
         </div>
         <div class="card-body">
             @if (session('success'))
-                <div class="alert alert-success">
+                <div class="alert alert-success mb-4">
                     {{ session('success') }}
                 </div>
             @endif
 
-            <div class="row">
-                <div class="col-md-12">
-                    <button type="button" class="btn btn-primary float-end mb-3"
-                            data-url="{{ route('admin.site-settings.edit') }}">Edit Settings</button>
+            <div class="row g-4">
+                <div class="col-md-6">
+                    <h6 class="text-uppercase text-muted mb-3">Brand Identity</h6>
+                    <div class="d-flex align-items-center gap-3 mb-3">
+                        <div class="border rounded p-2 bg-light">
+                            @if (!empty($settings?->logo_url))
+                                <img src="{{ $settings->logo_url }}" alt="Site logo" class="img-fluid" style="max-height: 64px;">
+                            @else
+                                <span class="text-muted small">No logo uploaded</span>
+                            @endif
+                        </div>
+                        <div>
+                            <p class="mb-1"><strong>{{ $settings->site_name ?? 'Not set' }}</strong></p>
+                            <p class="text-muted mb-0">{{ $settings->tagline ?? 'Tagline not set' }}</p>
+                        </div>
+                    </div>
+                    <div class="mb-3">
+                        <h6 class="fw-semibold">Top Bar Message</h6>
+                        <p class="mb-0 text-muted">{{ $settings->top_bar_message ?? 'Not set' }}</p>
+                    </div>
+                    <div class="mb-3">
+                        <h6 class="fw-semibold">SEO</h6>
+                        <dl class="row mb-0">
+                            <dt class="col-sm-4">Meta Title</dt>
+                            <dd class="col-sm-8">{{ $settings->meta_title ?? 'Not set' }}</dd>
+                            <dt class="col-sm-4">Meta Description</dt>
+                            <dd class="col-sm-8">{{ $settings->meta_description ?? 'Not set' }}</dd>
+                            <dt class="col-sm-4">Meta Keywords</dt>
+                            <dd class="col-sm-8">{{ $settings->meta_keywords ?? 'Not set' }}</dd>
+                        </dl>
+                    </div>
+                    <div class="mb-3">
+                        <h6 class="fw-semibold">Favicon</h6>
+                        @if (!empty($settings?->favicon_url))
+                            <img src="{{ $settings->favicon_url }}" alt="Favicon" class="img-thumbnail" style="max-height: 48px; width: auto;">
+                        @else
+                            <p class="text-muted mb-0">No favicon uploaded</p>
+                        @endif
+                    </div>
+                </div>
+                <div class="col-md-6">
+                    <h6 class="text-uppercase text-muted mb-3">Contact &amp; Footer</h6>
+                    <dl class="row mb-3">
+                        <dt class="col-sm-4">Email</dt>
+                        <dd class="col-sm-8">{{ $settings->contact_email ?? 'Not set' }}</dd>
+                        <dt class="col-sm-4">Phone</dt>
+                        <dd class="col-sm-8">{{ $settings->contact_phone ?? 'Not set' }}</dd>
+                        <dt class="col-sm-4">Address</dt>
+                        <dd class="col-sm-8">{{ $settings->address ?? 'Not set' }}</dd>
+                    </dl>
+                    <div class="mb-3">
+                        <h6 class="fw-semibold">Footer Text</h6>
+                        <p class="mb-0 text-muted">{{ $settings->footer_text ?? 'Not set' }}</p>
+                    </div>
+
+                    <div>
+                        <h6 class="text-uppercase text-muted mb-3">Social Links</h6>
+                        <ul class="list-group list-group-flush">
+                            <li class="list-group-item px-0 d-flex justify-content-between align-items-center">
+                                <span>Facebook</span>
+                                <span class="text-muted">{{ $settings->facebook_url ?? 'Not set' }}</span>
+                            </li>
+                            <li class="list-group-item px-0 d-flex justify-content-between align-items-center">
+                                <span>Instagram</span>
+                                <span class="text-muted">{{ $settings->instagram_url ?? 'Not set' }}</span>
+                            </li>
+                            <li class="list-group-item px-0 d-flex justify-content-between align-items-center">
+                                <span>Twitter / X</span>
+                                <span class="text-muted">{{ $settings->twitter_url ?? 'Not set' }}</span>
+                            </li>
+                            <li class="list-group-item px-0 d-flex justify-content-between align-items-center">
+                                <span>LinkedIn</span>
+                                <span class="text-muted">{{ $settings->linkedin_url ?? 'Not set' }}</span>
+                            </li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-
-            <table class="table">
-                <thead>
-                    <tr>
-                        <th>Setting</th>
-                        <th>Value</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>Site Name</td>
-                        <td>{{ $settings->site_name ?? 'Not set' }}</td>
-                    </tr>
-                    <tr>
-                        <td>Tagline</td>
-                        <td>{{ $settings->tagline ?? 'Not set' }}</td>
-                    </tr>
-                    <tr>
-                        <td>Meta Title</td>
-                        <td>{{ $settings->meta_title ?? 'Not set' }}</td>
-                    </tr>
-                    <tr>
-                        <td>Meta Description</td>
-                        <td>{{ $settings->meta_description ?? 'Not set' }}</td>
-                    </tr>
-                    <tr>
-                        <td>Meta Keywords</td>
-                        <td>{{ $settings->meta_keywords ?? 'Not set' }}</td>
-                    </tr>
-                </tbody>
-            </table>
         </div>
     </div>
 @endsection

--- a/resources/views/themes/xylo/layouts/footer.blade.php
+++ b/resources/views/themes/xylo/layouts/footer.blade.php
@@ -3,7 +3,21 @@
     <div class="row">
       <!-- Column 1: Logo -->
       <div class="col-12 col-md-3 mb-4">
-        <img src="https://i.ibb.co/dHx2ZR3/velstore.png" alt="Velstore Logo" class="img-fluid" style="max-width: 100px;">
+        <img src="{{ $siteSettings?->logo_url ?? asset('assets/images/logo-main.svg') }}" alt="{{ $siteSettings?->site_name ?? __('store.footer.footer_logo_alt') }}" class="img-fluid" style="max-width: 120px;">
+        @if (!empty($siteSettings?->tagline))
+          <p class="text-muted mt-3">{{ $siteSettings->tagline }}</p>
+        @endif
+        <ul class="list-unstyled text-muted small mt-3">
+          @if (!empty($siteSettings?->contact_email))
+            <li class="mb-2"><i class="fa-regular fa-envelope me-2"></i><a href="mailto:{{ $siteSettings->contact_email }}" class="text-muted text-decoration-none">{{ $siteSettings->contact_email }}</a></li>
+          @endif
+          @if (!empty($siteSettings?->contact_phone))
+            <li class="mb-2"><i class="fa fa-phone me-2"></i><a href="tel:{{ $siteSettings->contact_phone }}" class="text-muted text-decoration-none">{{ $siteSettings->contact_phone }}</a></li>
+          @endif
+          @if (!empty($siteSettings?->address))
+            <li><i class="fa fa-location-dot me-2"></i>{{ $siteSettings->address }}</li>
+          @endif
+        </ul>
       </div>
 
       <!-- Column 2: Account -->
@@ -28,10 +42,21 @@
     <div class="col-12 col-md-3 mb-4">
     <h5>{{ __('store.footer.follow_us') }}</h5>
     <div class="d-flex gap-3">
-        <a href="#" class="text-dark fs-5"><i class="fab fa-facebook-f"></i></a>
-        <a href="#" class="text-dark fs-5"><i class="fab fa-twitter"></i></a>
-        <a href="#" class="text-dark fs-5"><i class="fab fa-instagram"></i></a>
-        <a href="#" class="text-dark fs-5"><i class="fab fa-linkedin-in"></i></a>
+        @if (!empty($siteSettings?->facebook_url))
+          <a href="{{ $siteSettings->facebook_url }}" class="text-dark fs-5" target="_blank" rel="noopener"><i class="fab fa-facebook-f"></i></a>
+        @endif
+        @if (!empty($siteSettings?->twitter_url))
+          <a href="{{ $siteSettings->twitter_url }}" class="text-dark fs-5" target="_blank" rel="noopener"><i class="fab fa-twitter"></i></a>
+        @endif
+        @if (!empty($siteSettings?->instagram_url))
+          <a href="{{ $siteSettings->instagram_url }}" class="text-dark fs-5" target="_blank" rel="noopener"><i class="fab fa-instagram"></i></a>
+        @endif
+        @if (!empty($siteSettings?->linkedin_url))
+          <a href="{{ $siteSettings->linkedin_url }}" class="text-dark fs-5" target="_blank" rel="noopener"><i class="fab fa-linkedin-in"></i></a>
+        @endif
+        @if (empty($siteSettings?->facebook_url) && empty($siteSettings?->twitter_url) && empty($siteSettings?->instagram_url) && empty($siteSettings?->linkedin_url))
+          <span class="text-muted small">No social profiles configured yet.</span>
+        @endif
     </div>
     </div>
 
@@ -43,7 +68,7 @@
     <div class="container">
       <div class="row">
         <div class="col-12 d-flex justify-content-between flex-wrap small">
-          <span>{{ __('store.footer.copyright') }}</span>
+          <span>{{ $siteSettings?->footer_text ?? __('store.footer.copyright') }}</span>
           <span>{{ __('store.footer.powered_by') }}</span>
         </div>
       </div>

--- a/resources/views/themes/xylo/layouts/header.blade.php
+++ b/resources/views/themes/xylo/layouts/header.blade.php
@@ -2,7 +2,7 @@
 
     <div class="top-bar w-100 bg-light py-1 header-top-bar">
         <div class="text-center small">
-            {{ __('store.header.top_bar_message') }}
+            {{ $siteSettings?->top_bar_message ?? __('store.header.top_bar_message') }}
         </div>
     </div>
 
@@ -10,9 +10,12 @@
         <!-- Row 2: Logo Left / Search Right -->
         <div class="row align-items-center">
             <div class="col-md-4 col-6">
-                <a href="{{ route('xylo.home') }}" class="navbar-brand">
-                    <img src="https://i.ibb.co/dHx2ZR3/velstore.png" width="80" alt="Logo" />
+                <a href="{{ route('xylo.home') }}" class="navbar-brand d-inline-flex flex-column">
+                    <img src="{{ $siteSettings?->logo_url ?? asset('assets/images/logo-main.svg') }}" width="80" alt="{{ $siteSettings?->site_name ?? __('store.footer.footer_logo_alt') }}" />
                 </a>
+                @if (!empty($siteSettings?->tagline))
+                    <p class="small text-muted mb-0">{{ $siteSettings->tagline }}</p>
+                @endif
             </div>
             <div class="col-md-8 col-6 text-end">
                 <form class="d-flex justify-content-end" action="{{ url('/search') }}" method="GET">

--- a/resources/views/themes/xylo/layouts/master.blade.php
+++ b/resources/views/themes/xylo/layouts/master.blade.php
@@ -5,7 +5,16 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <title>{{ config('app.name', 'Laravel') }}</title>
+    <title>{{ $siteSettings?->meta_title ?? $siteSettings?->site_name ?? config('app.name', 'Laravel') }}</title>
+    @if (!empty($siteSettings?->meta_description))
+        <meta name="description" content="{{ $siteSettings->meta_description }}">
+    @endif
+    @if (!empty($siteSettings?->meta_keywords))
+        <meta name="keywords" content="{{ $siteSettings->meta_keywords }}">
+    @endif
+    @if (!empty($siteSettings?->favicon_url))
+        <link rel="icon" href="{{ $siteSettings->favicon_url }}">
+    @endif
     @if (!App::environment('testing'))
         @vite(['resources/views/themes/xylo/sass/app.scss'])
     @endif

--- a/tests/Feature/Concerns/CreatesAdminTestData.php
+++ b/tests/Feature/Concerns/CreatesAdminTestData.php
@@ -299,13 +299,20 @@ trait CreatesAdminTestData
         SiteSetting::create([
             'site_name' => 'Velstore',
             'tagline' => 'Tagline',
+            'top_bar_message' => 'Free shipping over $50',
             'meta_title' => 'Meta Title',
             'meta_description' => 'Meta description',
             'meta_keywords' => 'shop,store',
+            'logo' => 'assets/images/logo-main.svg',
+            'favicon' => 'favicon.ico',
             'contact_email' => 'info@example.com',
             'contact_phone' => '+123456789',
             'address' => '123 Market Street',
             'footer_text' => 'Copyright',
+            'facebook_url' => 'https://facebook.com/velstore',
+            'instagram_url' => 'https://instagram.com/velstore',
+            'twitter_url' => 'https://x.com/velstore',
+            'linkedin_url' => 'https://www.linkedin.com/company/velstore',
         ]);
     }
 }


### PR DESCRIPTION
## Summary
- expand the admin site settings form with branding, SEO, contact, and social fields plus file uploads for logo and favicon
- surface the configured site settings across the storefront layout, header, and footer while caching values for global availability
- seed default site settings, update factories, and wire the seeder into the main data import flow alongside a migration for new fields

## Testing
- `php artisan test` *(fails: vendor directory missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df95d13eb88329ac6ff5dd07164336