### PR TITLE
Refine admin payments management and demo data

### DIFF
--- a/app/Http/Controllers/Admin/PaymentController.php
+++ b/app/Http/Controllers/Admin/PaymentController.php
@@ -4,6 +4,9 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\Payment;
+use App\Models\PaymentGateway;
+use App\Models\Shop;
+use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Yajra\DataTables\Facades\DataTables;
 
@@ -11,38 +14,122 @@ class PaymentController extends Controller
 {
     public function index()
     {
-        return view('admin.payments.index');
+        $statusOptions = collect(Payment::STATUSES)->mapWithKeys(function ($status) {
+            $translationKey = 'cms.payments.' . $status;
+            $label = __($translationKey);
+
+            if ($label === $translationKey) {
+                $label = ucfirst(str_replace('_', ' ', $status));
+            }
+
+            return [$status => $label];
+        });
+
+        $gateways = PaymentGateway::query()->orderBy('name')->get(['id', 'name']);
+        $shops = Shop::query()->orderBy('name')->get(['id', 'name']);
+
+        return view('admin.payments.index', [
+            'statusOptions' => $statusOptions,
+            'gateways' => $gateways,
+            'shops' => $shops,
+        ]);
     }
 
     public function getData(Request $request)
     {
-        if ($request->ajax()) {
-            $payments = Payment::with(['order', 'gateway'])->select('payments.*');
+        abort_unless($request->ajax(), 404);
 
-            return DataTables::of($payments)
-                ->addColumn('user', fn($row) => '—')
-                ->addColumn('order', fn($row) => $row->order ? 'Order #' . $row->order->id : '—')
-                ->addColumn('gateway', fn($row) => $row->gateway?->name ?? '—')
-                ->addColumn('action', function ($row) {
-                    $showRoute = route('admin.payments.show', $row->id);
+        $payments = Payment::query()
+            ->with(['order.customer', 'order.details.product.shop', 'gateway'])
+            ->select('payments.*');
 
-                    return '<div class="btn-group btn-group-sm" role="group">
-                                <button type="button" class="btn btn-outline-primary btn-view-payment" data-url="' . $showRoute . '">
-                                    <i class="bi bi-eye-fill"></i>
-                                </button>
-                                <button type="button" class="btn btn-outline-danger btn-delete-payment" data-id="' . $row->id . '">
-                                    <i class="bi bi-trash-fill"></i>
-                                </button>
-                            </div>';
-                })
-                ->rawColumns(['action'])
-                ->make(true);
+        $status = $request->input('status');
+        if ($status && in_array($status, Payment::STATUSES, true)) {
+            $payments->forStatus($status);
         }
+
+        $payments->forGateway($request->integer('gateway_id'));
+        $payments->forShop($request->integer('shop_id'));
+
+        $dateFrom = $this->parseDate($request->input('date_from'));
+        $dateTo = $this->parseDate($request->input('date_to'), true);
+
+        if ($dateFrom) {
+            $payments->where('created_at', '>=', $dateFrom);
+        }
+
+        if ($dateTo) {
+            $payments->where('created_at', '<=', $dateTo);
+        }
+
+        return DataTables::of($payments)
+            ->addColumn('order', function ($row) {
+                if (! $row->order) {
+                    return '—';
+                }
+
+                $orderRoute = route('admin.orders.show', $row->order->id);
+
+                return '<a href="' . e($orderRoute) . '" class="text-decoration-none">#' . e($row->order->id) . '</a>';
+            })
+            ->addColumn('customer', function ($row) {
+                return $row->customer_display_name ?? '—';
+            })
+            ->addColumn('shops', function ($row) {
+                if (empty($row->shop_names)) {
+                    return '—';
+                }
+
+                return collect($row->shop_names)
+                    ->map(fn ($name) => e($name))
+                    ->implode(', ');
+            })
+            ->addColumn('gateway', fn ($row) => $row->gateway?->name ?? '—')
+            ->editColumn('amount', function ($row) {
+                $amount = number_format((float) $row->amount, 2);
+
+                return $row->currency ? $amount . ' ' . $row->currency : $amount;
+            })
+            ->addColumn('status_badge', function ($row) {
+                $statusVariants = [
+                    'completed' => 'success',
+                    'pending' => 'warning text-dark',
+                    'failed' => 'danger',
+                    'processing' => 'info text-dark',
+                    'refunded' => 'primary text-dark',
+                ];
+
+                $statusKey = $row->status ?? 'unknown';
+                $variant = $statusVariants[$statusKey] ?? 'secondary';
+                $translationKey = 'cms.payments.' . $statusKey;
+                $label = __($translationKey);
+
+                if ($label === $translationKey) {
+                    $label = ucfirst(str_replace('_', ' ', $statusKey));
+                }
+
+                return '<span class="badge bg-' . $variant . '">' . e($label) . '</span>';
+            })
+            ->editColumn('created_at', fn ($row) => optional($row->created_at)->format('d M Y, h:i A') ?? '—')
+            ->addColumn('action', function ($row) {
+                $showRoute = route('admin.payments.show', $row->id);
+
+                return '<div class="btn-group btn-group-sm" role="group">
+                            <button type="button" class="btn btn-outline-primary btn-view-payment" data-url="' . e($showRoute) . '">
+                                <i class="bi bi-eye-fill"></i>
+                            </button>
+                            <button type="button" class="btn btn-outline-danger btn-delete-payment" data-id="' . e($row->id) . '">
+                                <i class="bi bi-trash-fill"></i>
+                            </button>
+                        </div>';
+            })
+            ->rawColumns(['action', 'order', 'status_badge'])
+            ->make(true);
     }
 
     public function show($id)
     {
-        $payment = Payment::with(['order', 'gateway'])->findOrFail($id);
+        $payment = Payment::with(['order.customer', 'order.details.product.shop', 'gateway'])->findOrFail($id);
 
         return view('admin.payments.show', compact('payment'));
     }
@@ -52,5 +139,20 @@ class PaymentController extends Controller
         $payment->delete();
 
         return response()->json(['success' => true, 'message' => 'Payment deleted successfully.']);
+    }
+
+    protected function parseDate(?string $date, bool $endOfDay = false): ?Carbon
+    {
+        if (blank($date)) {
+            return null;
+        }
+
+        try {
+            $parsed = Carbon::createFromFormat('Y-m-d', $date);
+        } catch (\Exception) {
+            return null;
+        }
+
+        return $endOfDay ? $parsed->endOfDay() : $parsed->startOfDay();
     }
 }

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -9,6 +9,14 @@ class Payment extends Model
 {
     use HasFactory;
 
+    public const STATUSES = [
+        'pending',
+        'processing',
+        'completed',
+        'failed',
+        'refunded',
+    ];
+
     protected $fillable = [
         'order_id',
         'gateway_id',
@@ -39,5 +47,65 @@ class Payment extends Model
     public function refunds()
     {
         return $this->hasMany(Refund::class);
+    }
+
+    public function scopeForGateway($query, ?int $gatewayId)
+    {
+        return $query->when($gatewayId, fn ($builder) => $builder->where('gateway_id', $gatewayId));
+    }
+
+    public function scopeForStatus($query, ?string $status)
+    {
+        return $query->when(
+            $status,
+            fn ($builder) => $builder->where('status', $status)
+        );
+    }
+
+    public function scopeForShop($query, ?int $shopId)
+    {
+        return $query->when($shopId, function ($builder) use ($shopId) {
+            $builder->whereHas('order.details.product', function ($relationQuery) use ($shopId) {
+                $relationQuery->where('shop_id', $shopId);
+            });
+        });
+    }
+
+    public function getCustomerDisplayNameAttribute(): ?string
+    {
+        if ($this->relationLoaded('order') && $this->order) {
+            if ($this->order->relationLoaded('customer') && $this->order->customer) {
+                return $this->order->customer->name;
+            }
+
+            if ($this->order->guest_email) {
+                return $this->order->guest_email;
+            }
+        }
+
+        return null;
+    }
+
+    public function getShopNamesAttribute(): array
+    {
+        if (! $this->relationLoaded('order') || ! $this->order) {
+            return [];
+        }
+
+        $details = $this->order->relationLoaded('details')
+            ? $this->order->details
+            : $this->order->details()->with('product.shop')->get();
+
+        if ($details->isEmpty()) {
+            return [];
+        }
+
+        return $details
+            ->loadMissing('product.shop')
+            ->map(fn ($detail) => $detail->product?->shop?->name)
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
     }
 }

--- a/app/Models/Shop.php
+++ b/app/Models/Shop.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 
 class Shop extends Model
@@ -29,5 +30,10 @@ class Shop extends Model
                 $shop->slug = Str::slug($shop->name);
             }
         });
+    }
+
+    public function products(): HasMany
+    {
+        return $this->hasMany(Product::class);
     }
 }

--- a/database/seeders/PaymentSeeder.php
+++ b/database/seeders/PaymentSeeder.php
@@ -3,11 +3,17 @@
 namespace Database\Seeders;
 
 use App\Models\Order;
+use App\Models\OrderDetail;
 use App\Models\Payment;
 use App\Models\PaymentGateway;
+use App\Models\Product;
 use App\Models\ShippingAddress;
+use App\Models\Shop;
 use Carbon\Carbon;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 
 class PaymentSeeder extends Seeder
 {
@@ -16,44 +22,77 @@ class PaymentSeeder extends Seeder
      */
     public function run(): void
     {
-        $stripeGateway = PaymentGateway::firstOrCreate(
-            ['code' => 'stripe'],
+        DB::transaction(function () {
+            $gateways = $this->ensureGateways();
+
+            $this->seedFeaturedPayments($gateways);
+            $this->seedShopPayments($gateways);
+        });
+    }
+
+    protected function ensureGateways(): Collection
+    {
+        $gatewayDefinitions = collect([
             [
+                'code' => 'stripe',
                 'name' => 'Stripe',
                 'description' => 'Stripe payment gateway',
-                'is_active' => true,
-            ]
-        );
-
-        $paypalGateway = PaymentGateway::firstOrCreate(
-            ['code' => 'paypal'],
+            ],
             [
+                'code' => 'paypal',
                 'name' => 'PayPal',
                 'description' => 'PayPal payment gateway',
-                'is_active' => true,
-            ]
-        );
+            ],
+        ]);
 
-        $guestOrder = Order::updateOrCreate(
-            ['guest_email' => 'guest@example.com'],
-            [
-                'customer_id' => null,
-                'total_amount' => 100.00,
-                'status' => 'pending',
-            ]
-        );
+        return $gatewayDefinitions->map(function (array $definition) {
+            return PaymentGateway::firstOrCreate(
+                ['code' => $definition['code']],
+                [
+                    'name' => $definition['name'],
+                    'description' => $definition['description'],
+                    'is_active' => true,
+                ]
+            );
+        });
+    }
 
-        ShippingAddress::updateOrCreate(
-            ['order_id' => $guestOrder->id],
+    protected function seedFeaturedPayments(Collection $gateways): void
+    {
+        $products = Product::query()->with('shop')->orderBy('id')->take(3)->get();
+
+        if ($products->isEmpty()) {
+            return;
+        }
+
+        $stripeGateway = $gateways->firstWhere('code', 'stripe') ?? $gateways->first();
+        $paypalGateway = $gateways->firstWhere('code', 'paypal') ?? $gateways->first();
+
+        $guestOrderItems = [
             [
-                'customer_id' => null,
-                'name' => 'Guest Checkout',
-                'phone' => '+1-202-555-0199',
-                'address' => '789 Example Road',
-                'city' => 'Seedville',
-                'postal_code' => '60601',
-                'country' => 'United States',
-            ]
+                'product' => $products[0],
+                'quantity' => 2,
+                'price' => $products[0]->price ?: 50.00,
+            ],
+        ];
+
+        $guestOrder = $this->upsertOrder('guest@example.com', 'pending', $guestOrderItems, Carbon::now()->subDays(7));
+        $this->ensureShippingAddress($guestOrder, [
+            'name' => 'Guest Checkout',
+            'phone' => '+1-202-555-0199',
+            'address' => '789 Example Road',
+            'city' => 'Seedville',
+            'postal_code' => '60601',
+            'country' => 'United States',
+        ]);
+
+        $guestMeta = array_merge(
+            [
+                'seeded' => true,
+                'ip' => '127.0.0.1',
+                'source' => 'guest-demo',
+            ],
+            $this->shopMetaFromOrder($guestOrder)
         );
 
         Payment::updateOrCreate(
@@ -63,43 +102,43 @@ class PaymentSeeder extends Seeder
             ],
             [
                 'gateway_id' => $stripeGateway->id,
-                'amount' => 100.00,
-                'currency' => 'USD',
+                'amount' => $guestOrder->total_amount,
+                'currency' => $products[0]->currency ?? 'USD',
                 'status' => 'completed',
                 'response' => ['message' => 'Payment successful'],
-                'meta' => ['ip' => '127.0.0.1', 'seeded' => true],
+                'meta' => $guestMeta,
             ]
         );
 
-        $showcaseOrder = Order::updateOrCreate(
-            ['guest_email' => 'showcase-order@example.com'],
+        $showcaseItems = [
             [
-                'customer_id' => null,
-                'total_amount' => 180.75,
-                'status' => 'processing',
-            ]
-        );
+                'product' => $products[0],
+                'quantity' => 1,
+                'price' => $products[0]->price ?: 120.75,
+            ],
+            [
+                'product' => $products[1] ?? $products[0],
+                'quantity' => 1,
+                'price' => $products[1]->price ?? 60.00,
+            ],
+        ];
 
-        ShippingAddress::updateOrCreate(
-            ['order_id' => $showcaseOrder->id],
-            [
-                'customer_id' => null,
-                'name' => 'Showcase Customer',
-                'phone' => '+1-202-555-0199',
-                'address' => '789 Showcase Boulevard',
-                'city' => 'Showcase City',
-                'postal_code' => '94105',
-                'country' => 'United States',
-            ]
-        );
+        $showcaseOrder = $this->upsertOrder('showcase-order@example.com', 'processing', $showcaseItems, Carbon::now()->subDays(2));
+        $this->ensureShippingAddress($showcaseOrder, [
+            'name' => 'Showcase Customer',
+            'phone' => '+1-202-555-0199',
+            'address' => '789 Showcase Boulevard',
+            'city' => 'Showcase City',
+            'postal_code' => '94105',
+            'country' => 'United States',
+        ]);
 
-        $payments = [
+        $showcasePayments = [
             [
-                'gateway' => $stripeGateway,
                 'transaction_id' => 'STRIPE-ORDER-0003',
-                'amount' => 120.75,
+                'gateway' => $stripeGateway,
                 'status' => 'completed',
-                'currency' => 'USD',
+                'created_at' => Carbon::now()->subDays(2),
                 'response' => [
                     'message' => 'Payment captured successfully',
                     'authorization_code' => 'AUTH-STRIPE-12075',
@@ -108,14 +147,12 @@ class PaymentSeeder extends Seeder
                     'ip' => '203.0.113.5',
                     'captured_via' => 'dashboard',
                 ],
-                'created_at' => Carbon::now()->subDays(2),
             ],
             [
-                'gateway' => $paypalGateway,
                 'transaction_id' => 'PAYPAL-ORDER-0003',
-                'amount' => 60.00,
+                'gateway' => $paypalGateway,
                 'status' => 'pending',
-                'currency' => 'USD',
+                'created_at' => Carbon::now()->subDay(),
                 'response' => [
                     'message' => 'Awaiting capture from PayPal',
                     'status_detail' => 'Pending seller review',
@@ -124,31 +161,202 @@ class PaymentSeeder extends Seeder
                     'ip' => '198.51.100.42',
                     'initiated_via' => 'checkout',
                 ],
-                'created_at' => Carbon::now()->subDay(),
             ],
         ];
 
-        foreach ($payments as $data) {
+        foreach ($showcasePayments as $payload) {
             $payment = Payment::updateOrCreate(
                 [
                     'order_id' => $showcaseOrder->id,
-                    'transaction_id' => $data['transaction_id'],
+                    'transaction_id' => $payload['transaction_id'],
                 ],
                 [
-                    'gateway_id' => $data['gateway']->id,
-                    'amount' => $data['amount'],
-                    'currency' => $data['currency'],
-                    'status' => $data['status'],
-                    'response' => $data['response'],
-                    'meta' => $data['meta'],
+                    'gateway_id' => $payload['gateway']->id,
+                    'amount' => $showcaseOrder->total_amount,
+                    'currency' => $products[0]->currency ?? 'USD',
+                    'status' => $payload['status'],
+                    'response' => $payload['response'],
+                    'meta' => array_merge(
+                        ['seeded' => true],
+                        $payload['meta'],
+                        $this->shopMetaFromOrder($showcaseOrder)
+                    ),
                 ]
             );
 
-            if (isset($data['created_at'])) {
-                $payment->created_at = $data['created_at'];
-                $payment->updated_at = Carbon::now();
+            if (isset($payload['created_at'])) {
+                $payment->created_at = $payload['created_at'];
+                $payment->updated_at = $payload['created_at'];
                 $payment->save();
             }
         }
+    }
+
+    protected function seedShopPayments(Collection $gateways): void
+    {
+        $shops = Shop::with(['products' => fn ($query) => $query->orderBy('id')])->get();
+
+        if ($shops->isEmpty()) {
+            return;
+        }
+
+        $now = Carbon::now();
+
+        foreach ($shops as $index => $shop) {
+            $product = $shop->products->first();
+
+            if (! $product) {
+                continue;
+            }
+
+            $scenarios = [
+                [
+                    'status' => 'completed',
+                    'order_status' => 'completed',
+                    'suffix' => 'completed',
+                    'amount' => (float) $product->price ?: 75.00,
+                    'created_at' => $now->copy()->subDays(min($index, 6)),
+                ],
+                [
+                    'status' => 'pending',
+                    'order_status' => 'processing',
+                    'suffix' => 'pending',
+                    'amount' => max((float) $product->price * 0.65, 25.00),
+                    'created_at' => $now->copy()->subDays(min($index + 1, 8)),
+                ],
+            ];
+
+            foreach ($scenarios as $scenario) {
+                $email = sprintf('%s-%s@velstore.test', Str::slug($shop->name), $scenario['suffix']);
+
+                $order = $this->upsertOrder($email, $scenario['order_status'], [
+                    [
+                        'product' => $product,
+                        'quantity' => 1,
+                        'price' => $scenario['amount'],
+                    ],
+                ], $scenario['created_at']);
+
+                $this->ensureShippingAddress($order, [
+                    'name' => $shop->name,
+                    'phone' => '+1-202-555-0101',
+                    'address' => '123 Market Street',
+                    'city' => 'Commerce City',
+                    'postal_code' => '10001',
+                    'country' => 'United States',
+                ]);
+
+                $gateway = $gateways->random();
+
+                $payment = Payment::updateOrCreate(
+                    [
+                        'order_id' => $order->id,
+                        'transaction_id' => strtoupper(Str::slug($shop->name, '_')) . '-' . strtoupper($scenario['status']),
+                    ],
+                    [
+                        'gateway_id' => $gateway->id,
+                        'amount' => number_format($scenario['amount'], 2, '.', ''),
+                        'currency' => $product->currency ?? 'USD',
+                        'status' => $scenario['status'],
+                        'response' => [
+                            'message' => 'Seeded payment for ' . $shop->name,
+                            'gateway' => $gateway->code,
+                        ],
+                        'meta' => array_merge(
+                            [
+                                'seeded' => true,
+                                'shop_id' => $shop->id,
+                                'shop_name' => $shop->name,
+                                'vendor_id' => $shop->vendor_id,
+                            ],
+                            $this->shopMetaFromOrder($order)
+                        ),
+                    ]
+                );
+
+                if ($scenario['status'] === 'completed') {
+                    $payment->created_at = $scenario['created_at'];
+                    $payment->updated_at = $scenario['created_at'];
+                    $payment->save();
+                }
+            }
+        }
+    }
+
+    protected function upsertOrder(string $guestEmail, string $status, array $items, ?Carbon $timestamp = null): Order
+    {
+        $order = Order::firstOrNew(['guest_email' => $guestEmail]);
+        $order->customer_id = $order->customer_id ?? null;
+        $order->status = $status;
+        $order->save();
+
+        $this->syncOrderItems($order, $items);
+
+        if ($timestamp) {
+            $order->created_at = $timestamp;
+            $order->updated_at = $timestamp;
+            $order->save();
+        }
+
+        return $order;
+    }
+
+    protected function syncOrderItems(Order $order, array $items): void
+    {
+        $total = 0.0;
+
+        foreach ($items as $item) {
+            $product = $item['product'] instanceof Product ? $item['product'] : Product::find($item['product']);
+
+            if (! $product) {
+                continue;
+            }
+
+            $quantity = (int) ($item['quantity'] ?? 1);
+            $price = (float) ($item['price'] ?? $product->price ?? 0.0);
+            $total += $quantity * $price;
+
+            OrderDetail::updateOrCreate(
+                [
+                    'order_id' => $order->id,
+                    'product_id' => $product->id,
+                ],
+                [
+                    'quantity' => $quantity,
+                    'price' => $price,
+                ]
+            );
+        }
+
+        if ($total > 0) {
+            $order->total_amount = number_format($total, 2, '.', '');
+            $order->save();
+        }
+    }
+
+    protected function ensureShippingAddress(Order $order, array $attributes): void
+    {
+        ShippingAddress::updateOrCreate(
+            ['order_id' => $order->id],
+            array_merge(['customer_id' => null], $attributes)
+        );
+    }
+
+    protected function shopMetaFromOrder(Order $order): array
+    {
+        $shops = $order->details()
+            ->with('product.shop')
+            ->get()
+            ->map(fn ($detail) => $detail->product?->shop)
+            ->filter();
+
+        if ($shops->isEmpty()) {
+            return [];
+        }
+
+        return [
+            'shop_ids' => $shops->pluck('id')->unique()->values()->all(),
+            'shop_names' => $shops->pluck('name')->unique()->values()->all(),
+        ];
     }
 }

--- a/lang/ar/cms.php
+++ b/lang/ar/cms.php
@@ -227,6 +227,17 @@ return [
         'transaction' => 'المعاملة',
         'action' => 'الإجراء',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => 'مكتمل',
         'pending' => 'قيد الانتظار',

--- a/lang/de/cms.php
+++ b/lang/de/cms.php
@@ -227,6 +227,17 @@ return [
         'transaction' => 'Transaktion',
         'action' => 'Aktion',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => 'Abgeschlossen',
         'pending' => 'Ausstehend',

--- a/lang/en/cms.php
+++ b/lang/en/cms.php
@@ -305,6 +305,16 @@ return [
         'status' => 'Status',
         'transaction' => 'Transaction',
         'action' => 'Action',
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
 
         // Status Labels
         'completed' => 'Completed',

--- a/lang/es/cms.php
+++ b/lang/es/cms.php
@@ -227,6 +227,17 @@ return [
         'transaction' => 'Transacción',
         'action' => 'Acción',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => 'Completado',
         'pending' => 'Pendiente',

--- a/lang/fa/cms.php
+++ b/lang/fa/cms.php
@@ -227,6 +227,17 @@ return [
         'transaction' => 'تراکنش',
         'action' => 'عملیات',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => 'تکمیل شده',
         'pending' => 'در انتظار',

--- a/lang/fr/cms.php
+++ b/lang/fr/cms.php
@@ -227,6 +227,17 @@ return [
         'transaction' => 'Transaction',
         'action' => 'Action',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => 'Terminé',
         'pending' => 'En attente',

--- a/lang/hi/cms.php
+++ b/lang/hi/cms.php
@@ -227,6 +227,17 @@ return [
         'transaction' => 'लेन-देन',
         'action' => 'क्रिया',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => 'पूर्ण',
         'pending' => 'लंबित',

--- a/lang/id/cms.php
+++ b/lang/id/cms.php
@@ -227,6 +227,17 @@ return [
         'transaction' => 'Transaksi',
         'action' => 'Aksi',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => 'Selesai',
         'pending' => 'Tertunda',

--- a/lang/it/cms.php
+++ b/lang/it/cms.php
@@ -227,6 +227,17 @@ return [
         'transaction' => 'Transazione',
         'action' => 'Azione',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => 'Completato',
         'pending' => 'In sospeso',

--- a/lang/ja/cms.php
+++ b/lang/ja/cms.php
@@ -227,6 +227,17 @@ return [
         'transaction' => '取引',
         'action' => '操作',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => '完了',
         'pending' => '保留中',

--- a/lang/ko/cms.php
+++ b/lang/ko/cms.php
@@ -227,6 +227,17 @@ return [
         'transaction' => '거래',
         'action' => '작업',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => '완료',
         'pending' => '대기 중',

--- a/lang/nl/cms.php
+++ b/lang/nl/cms.php
@@ -226,6 +226,17 @@ return [
         'transaction' => 'Transactie',
         'action' => 'Actie',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => 'Voltooid',
         'pending' => 'In afwachting',

--- a/lang/pl/cms.php
+++ b/lang/pl/cms.php
@@ -227,6 +227,17 @@ return [
         'transaction' => 'Transakcja',
         'action' => 'Akcja',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => 'Zakończono',
         'pending' => 'Oczekujące',

--- a/lang/pt/cms.php
+++ b/lang/pt/cms.php
@@ -226,6 +226,17 @@ return [
         'transaction' => 'Transação',
         'action' => 'Ação',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => 'Concluído',
         'pending' => 'Pendente',

--- a/lang/ru/cms.php
+++ b/lang/ru/cms.php
@@ -227,6 +227,17 @@ return [
         'transaction' => 'Транзакция',
         'action' => 'Действие',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => 'Завершено',
         'pending' => 'В ожидании',

--- a/lang/th/cms.php
+++ b/lang/th/cms.php
@@ -227,6 +227,17 @@ return [
         'transaction' => 'ธุรกรรม',
         'action' => 'การดำเนินการ',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => 'เสร็จสมบูรณ์',
         'pending' => 'รอดำเนินการ',

--- a/lang/tr/cms.php
+++ b/lang/tr/cms.php
@@ -227,6 +227,17 @@ return [
         'transaction' => 'İşlem',
         'action' => 'İşlem',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => 'Tamamlandı',
         'pending' => 'Beklemede',

--- a/lang/vi/cms.php
+++ b/lang/vi/cms.php
@@ -227,6 +227,17 @@ return [
         'transaction' => 'Giao dịch',
         'action' => 'Hành động',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => 'Hoàn tất',
         'pending' => 'Đang chờ',

--- a/lang/zh/cms.php
+++ b/lang/zh/cms.php
@@ -227,6 +227,17 @@ return [
         'transaction' => '交易',
         'action' => '操作',
 
+        'shops' => 'Shops',
+
+        'filters_heading' => 'Filter payments',
+        'filters_all_statuses' => 'All statuses',
+        'filters_all_gateways' => 'All gateways',
+        'filters_all_shops' => 'All shops',
+        'filters_date_from' => 'Start date',
+        'filters_date_to' => 'End date',
+        'filters_apply' => 'Apply filters',
+        'filters_reset' => 'Reset filters',
+
         // Status Labels
         'completed' => '已完成',
         'pending' => '待处理',

--- a/resources/views/admin/payments/index.blade.php
+++ b/resources/views/admin/payments/index.blade.php
@@ -7,15 +7,63 @@
         </div>
 
         <div class="card-body">
+            <div class="border rounded-3 p-3 p-lg-4 bg-light-subtle mb-4">
+                <h6 class="mb-3 text-muted">{{ __('cms.payments.filters_heading') }}</h6>
+                <form id="payment-filters" class="row g-3">
+                    <div class="col-12 col-md-6 col-xl-3">
+                        <label for="filterStatus" class="form-label">{{ __('cms.payments.status') }}</label>
+                        <select id="filterStatus" class="form-select">
+                            <option value="">{{ __('cms.payments.filters_all_statuses') }}</option>
+                            @foreach ($statusOptions as $value => $label)
+                                <option value="{{ $value }}">{{ $label }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="col-12 col-md-6 col-xl-3">
+                        <label for="filterGateway" class="form-label">{{ __('cms.payment_gateways.title') }}</label>
+                        <select id="filterGateway" class="form-select">
+                            <option value="">{{ __('cms.payments.filters_all_gateways') }}</option>
+                            @foreach ($gateways as $gateway)
+                                <option value="{{ $gateway->id }}">{{ $gateway->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="col-12 col-md-6 col-xl-3">
+                        <label for="filterShop" class="form-label">{{ __('cms.payments.shops') }}</label>
+                        <select id="filterShop" class="form-select">
+                            <option value="">{{ __('cms.payments.filters_all_shops') }}</option>
+                            @foreach ($shops as $shop)
+                                <option value="{{ $shop->id }}">{{ $shop->name }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="col-12 col-md-6 col-xl-3">
+                        <label for="filterDateFrom" class="form-label">{{ __('cms.payments.filters_date_from') }}</label>
+                        <input type="date" id="filterDateFrom" class="form-control">
+                    </div>
+                    <div class="col-12 col-md-6 col-xl-3">
+                        <label for="filterDateTo" class="form-label">{{ __('cms.payments.filters_date_to') }}</label>
+                        <input type="date" id="filterDateTo" class="form-control">
+                    </div>
+                    <div class="col-12 col-md-6 col-xl-3 d-flex align-items-end gap-2">
+                        <button type="submit" class="btn btn-primary flex-grow-1">{{ __('cms.payments.filters_apply') }}</button>
+                        <button type="button" class="btn btn-outline-secondary" id="resetFilters">{{ __('cms.payments.filters_reset') }}</button>
+                    </div>
+                </form>
+            </div>
+
             <div class="table-responsive">
-                <table id="payments-table" class="table table-bordered table-striped align-middle mt-4 w-100">
+                <table id="payments-table" class="table table-bordered table-striped align-middle w-100">
                     <thead>
                         <tr>
                             <th>{{ __('cms.payments.id') }}</th>
                             <th>{{ __('cms.payments.order') }}</th>
+                            <th>{{ __('cms.payments.user') }}</th>
+                            <th>{{ __('cms.payments.shops') }}</th>
                             <th>{{ __('cms.payments.gateway') }}</th>
                             <th>{{ __('cms.payments.amount') }}</th>
                             <th>{{ __('cms.payments.status') }}</th>
+                            <th>{{ __('cms.payments.created_at') }}</th>
                             <th>{{ __('cms.payments.transaction') }}</th>
                             <th>{{ __('cms.payments.action') }}</th>
                         </tr>
@@ -70,18 +118,42 @@
             const table = $paymentsTable.DataTable({
                 processing: true,
                 serverSide: true,
-                ajax: "{{ route('admin.payments.getData') }}",
+                ajax: {
+                    url: "{{ route('admin.payments.getData') }}",
+                    data: function (data) {
+                        data.status = $('#filterStatus').val();
+                        data.gateway_id = $('#filterGateway').val();
+                        data.shop_id = $('#filterShop').val();
+                        data.date_from = $('#filterDateFrom').val();
+                        data.date_to = $('#filterDateTo').val();
+                    }
+                },
                 language: @json($datatableLang),
                 columns: [
-                    { data: 'id', name: 'id' },
-                    { data: 'order', name: 'order_id' },
+                    { data: 'id', name: 'payments.id' },
+                    { data: 'order', name: 'order_id', orderable: false, searchable: false },
+                    { data: 'customer', name: 'customer', orderable: false, searchable: false },
+                    { data: 'shops', name: 'shops', orderable: false, searchable: false },
                     { data: 'gateway', name: 'gateway_id' },
                     { data: 'amount', name: 'amount' },
-                    { data: 'status', name: 'status' },
+                    { data: 'status_badge', name: 'status', orderable: false, searchable: false },
+                    { data: 'created_at', name: 'created_at' },
                     { data: 'transaction_id', name: 'transaction_id' },
                     { data: 'action', orderable: false, searchable: false }
                 ],
+                order: [[7, 'desc']],
                 pageLength: 10
+            });
+
+            $('#payment-filters').on('submit', function (event) {
+                event.preventDefault();
+                table.ajax.reload();
+            });
+
+            $('#resetFilters').on('click', function () {
+                const form = document.getElementById('payment-filters');
+                form.reset();
+                table.ajax.reload();
             });
 
             $(document).on('click', '.btn-view-payment', function() {

--- a/resources/views/admin/payments/show.blade.php
+++ b/resources/views/admin/payments/show.blade.php
@@ -54,8 +54,26 @@
                             </td>
                         </tr>
                         <tr>
+                            <th>{{ __('cms.payments.user') }}</th>
+                            <td>{{ $payment->customer_display_name ?? $payment->order?->guest_email ?? $notAvailable }}</td>
+                        </tr>
+                        <tr>
                             <th>{{ __('cms.payments.gateway') }}</th>
                             <td>{{ $payment->gateway->name ?? $notAvailable }}</td>
+                        </tr>
+                        <tr>
+                            <th>{{ __('cms.payments.shops') }}</th>
+                            <td>
+                                @if (!empty($payment->shop_names))
+                                    <ul class="mb-0 ps-3">
+                                        @foreach ($payment->shop_names as $shopName)
+                                            <li>{{ $shopName }}</li>
+                                        @endforeach
+                                    </ul>
+                                @else
+                                    {{ $notAvailable }}
+                                @endif
+                            </td>
                         </tr>
                         <tr>
                             <th>{{ __('cms.payments.amount') }}</th>


### PR DESCRIPTION
## Summary
- add filtering UI and richer context to the admin payments DataTable
- expose customer and shop information throughout the payments controller and detail view
- extend the payment seeder to create shop-aware demo payments and add supporting translations

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df95816a0c83298241b8601d30d548