### PR TITLE
Add vendor shop management and storefront filtering

### DIFF
--- a/app/Http/Controllers/Admin/VendorController.php
+++ b/app/Http/Controllers/Admin/VendorController.php
@@ -4,8 +4,11 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Admin\VendorStoreRequest;
+use App\Models\Shop;
 use App\Models\Vendor;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\DB;
 use Yajra\DataTables\Facades\DataTables;
 
 class VendorController extends Controller
@@ -17,11 +20,22 @@ class VendorController extends Controller
             ->groupBy('status')
             ->pluck('aggregate', 'status');
 
+        $shopStatusCounts = Shop::query()
+            ->selectRaw('status, COUNT(*) as aggregate')
+            ->groupBy('status')
+            ->pluck('aggregate', 'status');
+
         $stats = [
-            'total' => $statusCounts->sum(),
-            'active' => (int) ($statusCounts['active'] ?? 0),
-            'inactive' => (int) ($statusCounts['inactive'] ?? 0),
-            'banned' => (int) ($statusCounts['banned'] ?? 0),
+            'vendors' => [
+                'total' => $statusCounts->sum(),
+                'active' => (int) ($statusCounts['active'] ?? 0),
+                'inactive' => (int) ($statusCounts['inactive'] ?? 0),
+                'banned' => (int) ($statusCounts['banned'] ?? 0),
+            ],
+            'shops' => [
+                'total' => $shopStatusCounts->sum(),
+                'active' => (int) ($shopStatusCounts['active'] ?? 0),
+            ],
         ];
 
         $statusOptions = $this->statusOptions();
@@ -35,6 +49,8 @@ class VendorController extends Controller
 
         $vendors = Vendor::query()
             ->select(['id', 'name', 'email', 'phone', 'status', 'created_at'])
+            ->withCount('shops')
+            ->with(['shops:id,vendor_id,name,status'])
             ->when(
                 in_array($status, Vendor::STATUSES, true),
                 fn ($query) => $query->where('status', $status)
@@ -42,6 +58,7 @@ class VendorController extends Controller
             ->latest('id');
 
         $statusOptions = $this->statusOptions();
+        $shopStatusLabels = $this->shopStatusLabels();
 
         return DataTables::of($vendors)
             ->editColumn('phone', fn ($vendor) => $vendor->phone ?: '—')
@@ -67,11 +84,35 @@ class VendorController extends Controller
 
                 return '<span class="badge ' . $badgeClass . '">' . e($label) . '</span>';
             })
+            ->addColumn('shops', function ($vendor) use ($shopStatusLabels) {
+                if (! $vendor->shops_count) {
+                    return '—';
+                }
+
+                $shopSummary = $vendor->shops
+                    ->map(function ($shop) use ($shopStatusLabels) {
+                        $status = strtolower((string) $shop->status);
+                        $label = $shopStatusLabels[$status] ?? ucfirst($status);
+
+                        return '<span class="d-block text-sm">' . e($shop->name) . ' <span class="text-muted">(' . e($label) . ')</span></span>';
+                    })
+                    ->implode('');
+
+                return '<div class="space-y-1">' . $shopSummary . '</div>';
+            })
             ->addColumn('action', function ($vendor) {
                 $deleteLabel = e(__('cms.vendors.delete_button'));
+                $viewLabel = e(__('cms.vendors.view_button'));
 
                 return <<<HTML
                     <div class="flex flex-col gap-2">
+                        <button type="button"
+                                class="btn btn-outline-primary btn-sm w-full"
+                                data-action="view-vendor"
+                                data-vendor-id="{$vendor->id}"
+                                title="{$viewLabel}">
+                            {$viewLabel}
+                        </button>
                         <button type="button"
                                 class="btn btn-outline-danger btn-sm w-full"
                                 data-action="delete-vendor"
@@ -82,23 +123,53 @@ class VendorController extends Controller
                     </div>
                 HTML;
             })
-            ->rawColumns(['status', 'action'])
+            ->rawColumns(['status', 'shops', 'action'])
             ->make(true);
     }
 
     public function create()
     {
         $statusOptions = $this->statusOptions();
+        $shopStatusOptions = $this->shopStatusOptions();
 
-        return view('admin.vendors.create', compact('statusOptions'));
+        return view('admin.vendors.create', compact('statusOptions', 'shopStatusOptions'));
     }
 
     public function store(VendorStoreRequest $request)
     {
-        Vendor::create($request->validated());
+        $validated = $request->validated();
+
+        DB::transaction(function () use ($validated) {
+            $vendor = Vendor::create(Arr::only($validated, ['name', 'email', 'password', 'phone', 'status']));
+
+            $shopSlug = $validated['shop_slug'] ?? Shop::generateUniqueSlug($validated['shop_name']);
+            if (Shop::where('slug', $shopSlug)->exists()) {
+                $shopSlug = Shop::generateUniqueSlug($shopSlug);
+            }
+
+            Shop::create([
+                'vendor_id' => $vendor->id,
+                'name' => $validated['shop_name'],
+                'slug' => $shopSlug,
+                'description' => $validated['shop_description'] ?? null,
+                'status' => $validated['shop_status'],
+            ]);
+        });
 
         return redirect()->route('admin.vendors.index')
             ->with('success', __('cms.vendors.success_create'));
+    }
+
+    public function show(Vendor $vendor)
+    {
+        $vendor->load(['shops' => function ($query) {
+            $query->orderBy('name')->withCount('products');
+        }])->loadCount('shops');
+
+        $totalProducts = $vendor->shops->sum('products_count');
+        $activeShopCount = $vendor->shops->where('status', 'active')->count();
+
+        return view('admin.vendors.show', compact('vendor', 'totalProducts', 'activeShopCount'));
     }
 
     public function destroy($id)
@@ -119,5 +190,19 @@ class VendorController extends Controller
                 $status => __('cms.vendors.status_' . $status),
             ])
             ->all();
+    }
+
+    private function shopStatusOptions(): array
+    {
+        return collect(Shop::STATUSES)
+            ->mapWithKeys(fn ($status) => [
+                $status => __('cms.vendors.shop_status_label_' . $status),
+            ])
+            ->all();
+    }
+
+    private function shopStatusLabels(): array
+    {
+        return $this->shopStatusOptions();
     }
 }

--- a/app/Http/Controllers/Store/ShopController.php
+++ b/app/Http/Controllers/Store/ShopController.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use App\Models\Brand;
 use App\Models\Category;
 use App\Models\Product;
+use App\Models\Shop;
 use Illuminate\Http\Request;
 use Illuminate\View\View;
 
@@ -38,6 +39,7 @@ class ShopController extends Controller
             'price_max' => (int) $request->input('price_max', 1000),
             'color' => array_filter((array) $request->input('color', [])),
             'size' => array_filter((array) $request->input('size', [])),
+            'shop' => array_filter((array) $request->input('shop', [])),
         ];
 
         $products = Product::with(['translation', 'variants.attributeValues'])
@@ -46,6 +48,9 @@ class ShopController extends Controller
             })
             ->when(! empty($filters['brand']), function ($query) use ($filters) {
                 $query->whereIn('brand_id', $filters['brand']);
+            })
+            ->when(! empty($filters['shop']), function ($query) use ($filters) {
+                $query->whereIn('shop_id', $filters['shop']);
             })
             ->whereHas('variants', function ($variantQuery) use ($filters) {
                 $variantQuery
@@ -77,6 +82,7 @@ class ShopController extends Controller
 
         $brands = Brand::with('translation')->withCount('products')->get();
         $categories = Category::with('translation')->withCount('products')->get();
+        $shops = Shop::where('status', 'active')->withCount('products')->orderBy('name')->get();
 
         if ($request->ajax()) {
             return view('themes.xylo.partials.product-list', compact('products'))->render();
@@ -86,6 +92,7 @@ class ShopController extends Controller
             'products' => $products,
             'categories' => $categories,
             'brands' => $brands,
+            'shops' => $shops,
             'filters' => $filters,
             'currentCategory' => $currentCategory,
         ]);

--- a/app/Http/Requests/Admin/VendorStoreRequest.php
+++ b/app/Http/Requests/Admin/VendorStoreRequest.php
@@ -2,8 +2,10 @@
 
 namespace App\Http\Requests\Admin;
 
+use App\Models\Shop;
 use App\Models\Vendor;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rule;
 
 class VendorStoreRequest extends FormRequest
@@ -20,7 +22,17 @@ class VendorStoreRequest extends FormRequest
             'email' => $this->whenFilled('email', fn ($value) => strtolower(trim((string) $value))),
             'phone' => $this->whenFilled('phone', fn ($value) => trim((string) $value) ?: null),
             'status' => $this->whenFilled('status', fn ($value) => strtolower(trim((string) $value))),
+            'shop_name' => $this->whenFilled('shop_name', fn ($value) => trim((string) $value)),
+            'shop_slug' => $this->whenFilled('shop_slug', fn ($value) => Str::slug((string) $value) ?: null),
+            'shop_description' => $this->whenFilled('shop_description', fn ($value) => trim((string) $value) ?: null),
+            'shop_status' => $this->whenFilled('shop_status', fn ($value) => strtolower(trim((string) $value))),
         ]);
+
+        if (! $this->filled('shop_slug') && $this->filled('shop_name')) {
+            $this->merge([
+                'shop_slug' => Str::slug((string) $this->input('shop_name')) ?: null,
+            ]);
+        }
     }
 
     public function rules(): array
@@ -38,6 +50,10 @@ class VendorStoreRequest extends FormRequest
             'password_confirmation' => ['required', 'string', 'min:8'],
             'phone' => ['nullable', 'string', 'max:20', 'regex:/^\+?[0-9\s\-]+$/'],
             'status' => ['required', Rule::in(Vendor::STATUSES)],
+            'shop_name' => ['required', 'string', 'max:255'],
+            'shop_slug' => ['nullable', 'string', 'max:255', Rule::unique('shops', 'slug')],
+            'shop_description' => ['nullable', 'string', 'max:500'],
+            'shop_status' => ['required', Rule::in(Shop::STATUSES)],
         ];
     }
 
@@ -47,6 +63,7 @@ class VendorStoreRequest extends FormRequest
             'password.confirmed' => __('validation.confirmed', ['attribute' => __('cms.vendors.password')]),
             'password.regex' => __('cms.vendors.password_symbol_validation'),
             'phone.regex' => __('validation.regex', ['attribute' => __('cms.vendors.phone_optional')]),
+            'shop_slug.unique' => __('validation.unique', ['attribute' => __('cms.vendors.shop_slug')]),
         ];
     }
 

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\App;
 
 class Product extends Model
@@ -62,6 +63,11 @@ class Product extends Model
     public function brand()
     {
         return $this->belongsTo(Brand::class);
+    }
+
+    public function shop(): BelongsTo
+    {
+        return $this->belongsTo(Shop::class);
     }
 
     public function vendor()

--- a/app/Models/Shop.php
+++ b/app/Models/Shop.php
@@ -4,11 +4,15 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Str;
 
 class Shop extends Model
 {
     use HasFactory;
+
+    public const STATUSES = ['active', 'inactive'];
 
     protected $fillable = [
         'vendor_id',
@@ -29,5 +33,29 @@ class Shop extends Model
                 $shop->slug = Str::slug($shop->name);
             }
         });
+    }
+
+    public static function generateUniqueSlug(string $value): string
+    {
+        $baseSlug = Str::slug($value) ?: Str::slug(Str::random(8));
+        $slug = $baseSlug;
+        $counter = 1;
+
+        while (static::where('slug', $slug)->exists()) {
+            $slug = $baseSlug . '-' . $counter;
+            $counter++;
+        }
+
+        return $slug;
+    }
+
+    public function vendor(): BelongsTo
+    {
+        return $this->belongsTo(Vendor::class);
+    }
+
+    public function products(): HasMany
+    {
+        return $this->hasMany(Product::class);
     }
 }

--- a/app/Models/Vendor.php
+++ b/app/Models/Vendor.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
@@ -19,4 +20,9 @@ class Vendor extends Authenticatable
     protected $hidden = ['password'];
 
     protected $casts = ['password' => 'hashed'];
+
+    public function shops(): HasMany
+    {
+        return $this->hasMany(Shop::class);
+    }
 }

--- a/app/Repositories/Admin/Product/ProductRepository.php
+++ b/app/Repositories/Admin/Product/ProductRepository.php
@@ -7,6 +7,7 @@ use App\Models\ProductImage;
 use App\Models\Shop;
 use App\Services\Admin\ImageService;
 use Illuminate\Support\Str;
+use RuntimeException;
 
 class ProductRepository implements ProductRepositoryInterface
 {
@@ -40,14 +41,14 @@ class ProductRepository implements ProductRepositoryInterface
 
         $defaultCurrencyCode = getWebConfig('default_currency', 'USD');
 
-        $shop = Shop::where('vendor_id', 1)->first();
+        $shop = Shop::where('status', 'active')->orderBy('id')->first();
 
         if (! $shop) {
-            throw new Exception('No shop found for this vendor.');
+            throw new RuntimeException('No active shop found for product assignment.');
         }
 
         $product = Product::create([
-            'vendor_id' => 1,
+            'vendor_id' => $shop->vendor_id,
             'shop_id' => $shop->id,
             'category_id' => $data['category_id'],
             'price' => currency_to_usd($data['price'], $defaultCurrencyCode),

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,7 @@ class DatabaseSeeder extends Seeder
             ProductVariantLocaleSeeder::class,
             CurrencySeeder::class,
             VendorSeeder::class,
+            ShopSeeder::class,
             ProductSeeder::class,
             ProductReviewSeeder::class,
             CouponSeeder::class,

--- a/database/seeders/ShopSeeder.php
+++ b/database/seeders/ShopSeeder.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Shop;
+use App\Models\Vendor;
+use Illuminate\Database\Seeder;
+
+class ShopSeeder extends Seeder
+{
+    public function run(): void
+    {
+        if (Shop::query()->exists()) {
+            return;
+        }
+
+        $vendors = Vendor::query()->get();
+
+        if ($vendors->isEmpty()) {
+            $vendors = Vendor::factory()->count(3)->create();
+        }
+
+        foreach ($vendors as $vendor) {
+            Shop::factory()->create([
+                'vendor_id' => $vendor->id,
+                'status' => $vendor->status === 'banned' ? 'inactive' : 'active',
+            ]);
+        }
+    }
+}

--- a/lang/en/cms.php
+++ b/lang/en/cms.php
@@ -563,7 +563,9 @@ return [
 
         // Form labels
         'vendor_details_heading' => 'Vendor details',
+        'vendor_details_hint' => 'Tell us who the vendor is so we can keep their profile consistent everywhere.',
         'account_security_heading' => 'Account security',
+        'account_security_hint' => 'Create secure credentials and decide how the account should behave.',
         'vendor_name' => 'Vendor name',
         'vendor_email' => 'Vendor email',
         'phone_optional' => 'Phone (optional)',
@@ -574,12 +576,22 @@ return [
         'password_requirements' => 'Use at least 8 characters, including one symbol.',
         'phone_format_hint' => 'Include the country code, e.g. +1 555 123 4567.',
         'password_symbol_validation' => 'The password must include at least one symbol character.',
+        'shop_details_heading' => 'Shop profile',
+        'shop_details_hint' => 'Every vendor needs a shop so customers can browse their catalogue.',
+        'shop_name' => 'Shop name',
+        'shop_slug' => 'Shop URL slug',
+        'shop_slug_placeholder' => 'e.g. aurora-studios',
+        'shop_slug_hint' => 'We will auto-generate this from the shop name if you leave it blank.',
+        'shop_description' => 'Shop description',
+        'shop_description_placeholder' => 'Tell customers what makes this shop special (max 500 characters).',
+        'shop_status' => 'Shop status',
 
         // Buttons
         'add_vendor' => 'Add Vendor',
         'register_button' => 'Create vendor',
         'cancel_button' => 'Cancel',
         'delete_button' => 'Delete vendor',
+        'view_button' => 'View profile',
         'cancel' => 'Cancel',
         'delete' => 'Delete',
 
@@ -596,6 +608,22 @@ return [
         // Filters
         'filter_status_label' => 'Filter by status',
         'filter_status_all' => 'All statuses',
+
+        // Shop support
+        'shops' => 'Shops',
+        'total_shops' => 'Total shops',
+        'active_shops' => 'Active shops',
+        'shop_list_title' => 'Associated shops',
+        'shops_empty_state' => 'This vendor does not manage any shops yet.',
+        'shop_products_count' => 'Products',
+        'shop_status_label_active' => 'Active',
+        'shop_status_label_inactive' => 'Inactive',
+        'shop_description_empty' => 'No description provided yet.',
+        'total_shop_products' => 'Products across shops',
+        'shop_count_label' => 'Number of shops',
+        'profile_description' => 'Vendor account overview and connected shops.',
+        'profile_overview_heading' => 'Contact details',
+        'vendor_metrics_heading' => 'Marketplace metrics',
 
         // Legacy keys kept for backwards compatibility
         'title_list' => 'Vendor List',

--- a/resources/views/admin/vendors/create.blade.php
+++ b/resources/views/admin/vendors/create.blade.php
@@ -11,12 +11,19 @@
 </x-admin.page-header>
 
 <x-admin.card class="mt-6">
-    <form action="{{ route('admin.vendors.store') }}" method="POST" class="grid gap-6">
+    <form action="{{ route('admin.vendors.store') }}" method="POST" class="grid gap-8">
         @csrf
 
         <div class="grid gap-6 lg:grid-cols-2">
             <div class="space-y-4">
-                <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">{{ __('cms.vendors.vendor_details_heading') }}</h3>
+                <div>
+                    <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+                        {{ __('cms.vendors.vendor_details_heading') }}
+                    </h3>
+                    <p class="mt-1 text-sm text-gray-500">
+                        {{ __('cms.vendors.vendor_details_hint') }}
+                    </p>
+                </div>
 
                 <div class="grid gap-4">
                     <div>
@@ -78,7 +85,14 @@
             </div>
 
             <div class="space-y-4">
-                <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">{{ __('cms.vendors.account_security_heading') }}</h3>
+                <div>
+                    <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+                        {{ __('cms.vendors.account_security_heading') }}
+                    </h3>
+                    <p class="mt-1 text-sm text-gray-500">
+                        {{ __('cms.vendors.account_security_hint') }}
+                    </p>
+                </div>
 
                 <div class="grid gap-4">
                     <div>
@@ -138,6 +152,88 @@
             </div>
         </div>
 
+        <div class="space-y-4">
+            <div>
+                <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+                    {{ __('cms.vendors.shop_details_heading') }}
+                </h3>
+                <p class="mt-1 text-sm text-gray-500">
+                    {{ __('cms.vendors.shop_details_hint') }}
+                </p>
+            </div>
+
+            <div class="grid gap-4 lg:grid-cols-2">
+                <div>
+                    <label for="shop_name" class="form-label">{{ __('cms.vendors.shop_name') }}</label>
+                    <input
+                        id="shop_name"
+                        type="text"
+                        name="shop_name"
+                        value="{{ old('shop_name') }}"
+                        maxlength="255"
+                        class="form-control @error('shop_name') is-invalid @enderror"
+                        required
+                    >
+                    @error('shop_name')
+                        <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div>
+                    <label for="shop_slug" class="form-label">{{ __('cms.vendors.shop_slug') }}</label>
+                    <input
+                        id="shop_slug"
+                        type="text"
+                        name="shop_slug"
+                        value="{{ old('shop_slug') }}"
+                        maxlength="255"
+                        class="form-control @error('shop_slug') is-invalid @enderror"
+                        placeholder="{{ __('cms.vendors.shop_slug_placeholder') }}"
+                    >
+                    <p class="form-text text-xs text-gray-500 mt-1">
+                        {{ __('cms.vendors.shop_slug_hint') }}
+                    </p>
+                    @error('shop_slug')
+                        <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div class="lg:col-span-2">
+                    <label for="shop_description" class="form-label">{{ __('cms.vendors.shop_description') }}</label>
+                    <textarea
+                        id="shop_description"
+                        name="shop_description"
+                        rows="4"
+                        maxlength="500"
+                        class="form-textarea @error('shop_description') is-invalid @enderror"
+                        placeholder="{{ __('cms.vendors.shop_description_placeholder') }}"
+                    >{{ old('shop_description') }}</textarea>
+                    @error('shop_description')
+                        <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                    @enderror
+                </div>
+
+                <div>
+                    <label for="shop_status" class="form-label">{{ __('cms.vendors.shop_status') }}</label>
+                    <select
+                        id="shop_status"
+                        name="shop_status"
+                        class="form-select @error('shop_status') is-invalid @enderror"
+                        required
+                    >
+                        @foreach ($shopStatusOptions as $value => $label)
+                            <option value="{{ $value }}" @selected(old('shop_status', 'active') === $value)>
+                                {{ $label }}
+                            </option>
+                        @endforeach
+                    </select>
+                    @error('shop_status')
+                        <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                    @enderror
+                </div>
+            </div>
+        </div>
+
         <div class="flex flex-wrap justify-end gap-3">
             <button type="submit" class="btn btn-primary">
                 {{ __('cms.vendors.register_button') }}
@@ -148,4 +244,38 @@
         </div>
     </form>
 </x-admin.card>
+
+@push('scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            const nameInput = document.getElementById('shop_name');
+            const slugInput = document.getElementById('shop_slug');
+
+            if (! nameInput || ! slugInput) {
+                return;
+            }
+
+            const slugify = (value) => value
+                .toString()
+                .toLowerCase()
+                .trim()
+                .replace(/[^a-z0-9\s-]/g, '')
+                .replace(/\s+/g, '-')
+                .replace(/-+/g, '-');
+
+            nameInput.addEventListener('input', (event) => {
+                if (slugInput.dataset.touched === 'true') {
+                    return;
+                }
+
+                slugInput.value = slugify(event.target.value);
+            });
+
+            slugInput.addEventListener('input', () => {
+                slugInput.dataset.touched = 'true';
+                slugInput.value = slugify(slugInput.value);
+            });
+        });
+    </script>
+@endpush
 @endsection

--- a/resources/views/admin/vendors/index.blade.php
+++ b/resources/views/admin/vendors/index.blade.php
@@ -2,11 +2,15 @@
 
 @php
     $datatableLang = __('cms.datatables');
-    $vendorStats = $stats ?? [
+    $vendorStats = $stats['vendors'] ?? [
         'total' => 0,
         'active' => 0,
         'inactive' => 0,
         'banned' => 0,
+    ];
+    $shopStats = $stats['shops'] ?? [
+        'total' => 0,
+        'active' => 0,
     ];
 @endphp
 
@@ -21,7 +25,7 @@
 </x-admin.page-header>
 
 <x-admin.card>
-    <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+    <div class="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
         <div class="p-4 rounded-lg bg-slate-50 border border-slate-200">
             <p class="text-xs uppercase tracking-wide text-slate-600 mb-1">{{ __('cms.vendors.total_vendors') }}</p>
             <p class="text-xl font-semibold text-slate-900">{{ number_format($vendorStats['total']) }}</p>
@@ -37,6 +41,14 @@
         <div class="p-4 rounded-lg bg-rose-50 border border-rose-100">
             <p class="text-xs uppercase tracking-wide text-rose-600 mb-1">{{ __('cms.vendors.banned_vendors') }}</p>
             <p class="text-xl font-semibold text-rose-900">{{ number_format($vendorStats['banned']) }}</p>
+        </div>
+        <div class="p-4 rounded-lg bg-indigo-50 border border-indigo-100">
+            <p class="text-xs uppercase tracking-wide text-indigo-600 mb-1">{{ __('cms.vendors.total_shops') }}</p>
+            <p class="text-xl font-semibold text-indigo-900">{{ number_format($shopStats['total']) }}</p>
+        </div>
+        <div class="p-4 rounded-lg bg-cyan-50 border border-cyan-100">
+            <p class="text-xs uppercase tracking-wide text-cyan-600 mb-1">{{ __('cms.vendors.active_shops') }}</p>
+            <p class="text-xl font-semibold text-cyan-900">{{ number_format($shopStats['active']) }}</p>
         </div>
     </div>
 </x-admin.card>
@@ -61,6 +73,7 @@
         __('cms.vendors.email'),
         __('cms.vendors.phone'),
         __('cms.vendors.registered_at'),
+        __('cms.vendors.shops'),
         __('cms.vendors.status'),
         __('cms.vendors.actions'),
     ]">
@@ -91,6 +104,7 @@
         document.addEventListener('DOMContentLoaded', () => {
             const routes = {
                 data: '{{ route('admin.vendors.data') }}',
+                show: '{{ route('admin.vendors.show', ['vendor' => '__ID__']) }}',
                 destroy: '{{ route('admin.vendors.destroy', ['id' => '__ID__']) }}',
             };
 
@@ -116,6 +130,7 @@
                     { data: 'email', name: 'email' },
                     { data: 'phone', name: 'phone', defaultContent: '—' },
                     { data: 'registered_at', name: 'registered_at', orderable: false, searchable: false, defaultContent: '—' },
+                    { data: 'shops', name: 'shops', orderable: false, searchable: false, defaultContent: '—' },
                     { data: 'status', name: 'status', orderable: false, searchable: false },
                     { data: 'action', orderable: false, searchable: false },
                 ],
@@ -133,14 +148,22 @@
             let vendorToDelete = null;
 
             document.addEventListener('click', (event) => {
-                const trigger = event.target.closest('[data-action="delete-vendor"]');
-                if (! trigger) {
+                const deleteTrigger = event.target.closest('[data-action="delete-vendor"]');
+                if (deleteTrigger) {
+                    vendorToDelete = deleteTrigger.getAttribute('data-vendor-id');
+                    if (vendorToDelete && deleteModal) {
+                        deleteModal.show();
+                    }
+
                     return;
                 }
 
-                vendorToDelete = trigger.getAttribute('data-vendor-id');
-                if (vendorToDelete && deleteModal) {
-                    deleteModal.show();
+                const viewTrigger = event.target.closest('[data-action="view-vendor"]');
+                if (viewTrigger) {
+                    const vendorId = viewTrigger.getAttribute('data-vendor-id');
+                    if (vendorId) {
+                        window.location.href = routes.show.replace('__ID__', vendorId);
+                    }
                 }
             });
 

--- a/resources/views/admin/vendors/show.blade.php
+++ b/resources/views/admin/vendors/show.blade.php
@@ -1,0 +1,123 @@
+@extends('admin.layouts.admin')
+
+@section('content')
+<x-admin.page-header
+    :title="$vendor->name"
+    :description="__('cms.vendors.profile_description')"
+>
+    <x-admin.button-link href="{{ route('admin.vendors.index') }}" class="btn-outline">
+        {{ __('cms.vendors.back_to_index') }}
+    </x-admin.button-link>
+</x-admin.page-header>
+
+<div class="grid gap-6 mt-6 xl:grid-cols-3">
+    <x-admin.card class="xl:col-span-2">
+        <div class="grid gap-6 md:grid-cols-2">
+            <div class="space-y-3">
+                <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+                    {{ __('cms.vendors.profile_overview_heading') }}
+                </h3>
+                <dl class="space-y-3 text-sm text-gray-700">
+                    <div>
+                        <dt class="font-medium text-gray-500">{{ __('cms.vendors.vendor_name') }}</dt>
+                        <dd class="mt-1 text-gray-900">{{ $vendor->name }}</dd>
+                    </div>
+                    <div>
+                        <dt class="font-medium text-gray-500">{{ __('cms.vendors.vendor_email') }}</dt>
+                        <dd class="mt-1 text-gray-900">{{ $vendor->email }}</dd>
+                    </div>
+                    <div>
+                        <dt class="font-medium text-gray-500">{{ __('cms.vendors.phone_optional') }}</dt>
+                        <dd class="mt-1 text-gray-900">{{ $vendor->phone ?: '—' }}</dd>
+                    </div>
+                </dl>
+            </div>
+
+            <div class="space-y-3">
+                <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+                    {{ __('cms.vendors.account_security_heading') }}
+                </h3>
+                <dl class="space-y-3 text-sm text-gray-700">
+                    <div>
+                        <dt class="font-medium text-gray-500">{{ __('cms.vendors.status_label') }}</dt>
+                        <dd class="mt-1">
+                            @php
+                                $statusBadge = match($vendor->status) {
+                                    'active' => 'badge-success',
+                                    'inactive' => 'badge-warning',
+                                    'banned' => 'badge-danger',
+                                    default => 'badge-secondary',
+                                };
+                            @endphp
+                            <span class="badge {{ $statusBadge }}">
+                                {{ __('cms.vendors.status_' . ($vendor->status ?? 'unknown')) }}
+                            </span>
+                        </dd>
+                    </div>
+                    <div>
+                        <dt class="font-medium text-gray-500">{{ __('cms.vendors.registered_at') }}</dt>
+                        <dd class="mt-1 text-gray-900">
+                            {{ $vendor->created_at ? $vendor->created_at->timezone(config('app.timezone'))->format('M j, Y H:i') : '—' }}
+                        </dd>
+                    </div>
+                    <div>
+                        <dt class="font-medium text-gray-500">{{ __('cms.vendors.shop_count_label') }}</dt>
+                        <dd class="mt-1 text-gray-900">{{ number_format($vendor->shops_count) }}</dd>
+                    </div>
+                </dl>
+            </div>
+        </div>
+    </x-admin.card>
+
+    <x-admin.card>
+        <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">
+            {{ __('cms.vendors.vendor_metrics_heading') }}
+        </h3>
+        <dl class="mt-4 space-y-4 text-sm text-gray-700">
+            <div class="flex items-center justify-between">
+                <dt>{{ __('cms.vendors.total_shops') }}</dt>
+                <dd class="font-semibold text-gray-900">{{ number_format($vendor->shops_count) }}</dd>
+            </div>
+            <div class="flex items-center justify-between">
+                <dt>{{ __('cms.vendors.total_shop_products') }}</dt>
+                <dd class="font-semibold text-gray-900">{{ number_format($totalProducts) }}</dd>
+            </div>
+            <div class="flex items-center justify-between">
+                <dt>{{ __('cms.vendors.active_shops') }}</dt>
+                <dd class="font-semibold text-gray-900">{{ number_format($activeShopCount) }}</dd>
+            </div>
+        </dl>
+    </x-admin.card>
+</div>
+
+<x-admin.card class="mt-6" :title="__('cms.vendors.shop_list_title')">
+    @if ($vendor->shops->isEmpty())
+        <p class="text-sm text-gray-600">{{ __('cms.vendors.shops_empty_state') }}</p>
+    @else
+        <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+            @foreach ($vendor->shops as $shop)
+                <div class="p-4 border rounded-lg border-slate-200 bg-slate-50">
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <h4 class="text-base font-semibold text-slate-900">{{ $shop->name }}</h4>
+                            <p class="text-xs text-slate-500">{{ $shop->slug }}</p>
+                        </div>
+                        <span class="badge {{ $shop->status === 'active' ? 'badge-success' : 'badge-secondary' }}">
+                            {{ __('cms.vendors.shop_status_label_' . $shop->status) }}
+                        </span>
+                    </div>
+                    <p class="mt-3 text-sm text-slate-600 line-clamp-3">
+                        {{ $shop->description ?: __('cms.vendors.shop_description_empty') }}
+                    </p>
+                    <dl class="mt-4 space-y-2 text-sm text-slate-600">
+                        <div class="flex items-center justify-between">
+                            <dt>{{ __('cms.vendors.shop_products_count') }}</dt>
+                            <dd class="font-semibold text-slate-900">{{ number_format($shop->products_count) }}</dd>
+                        </div>
+                    </dl>
+                </div>
+            @endforeach
+        </div>
+    @endif
+</x-admin.card>
+@endsection

--- a/resources/views/themes/xylo/shop.blade.php
+++ b/resources/views/themes/xylo/shop.blade.php
@@ -12,6 +12,7 @@
             'price_max' => 1000,
             'color' => [],
             'size' => [],
+            'shop' => [],
         ];
     @endphp
     <section class="products-home py-5 mb-5 main-shop">
@@ -19,6 +20,15 @@
         <div class="row">
             <aside class="col-md-3 d-none d-lg-inline">
                 <div class="sidebar" id="filterSidebar">
+                    <h5 class="mb-3">SHOPS</h5>
+                    @foreach($shops ?? [] as $shop)
+                    <div class="form-check mb-3">
+                        <input class="form-check-input filter-input" type="checkbox" name="shop[]" value="{{ $shop->id }}" @checked(in_array($shop->id, $filters['shop']))>
+                        <label class="form-check-label">{{ $shop->name }}</label>
+                        <span class="text-muted">({{ $shop->products_count }})</span>
+                    </div>
+                    @endforeach
+
                     <h5 class="mb-3">BRANDS</h5>
                     @foreach($brands as $brand)
                     <div class="form-check mb-3">

--- a/routes/web.php
+++ b/routes/web.php
@@ -125,9 +125,10 @@ Route::prefix('admin')->name('admin.')->group(function () {
     /* Vendors */
     Route::get('vendors', [VendorController::class, 'index'])->name('vendors.index');
     Route::get('vendors/data', [VendorController::class, 'getVendorData'])->name('vendors.data');
-    Route::delete('vendors/{id}', [VendorController::class, 'destroy'])->name('vendors.destroy');
     Route::get('vendors/create', [VendorController::class, 'create'])->name('vendors.create');
     Route::post('vendors', [VendorController::class, 'store'])->name('vendors.store');
+    Route::get('vendors/{vendor}', [VendorController::class, 'show'])->name('vendors.show');
+    Route::delete('vendors/{id}', [VendorController::class, 'destroy'])->name('vendors.destroy');
 
     /* Pages */
     Route::resource('pages', PageController::class);


### PR DESCRIPTION
## Summary
- refactor the admin vendor create experience to capture shop profile data with automatic slugging
- enhance vendor listings with shop metrics, a detail page, and safer product creation defaults tied to active shops
- seed shops alongside vendors and expose shop filters across the storefront catalogue

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df9550d070832995edb60b29a75892