### PR TITLE
Simplify admin attributes interface and centralize seeder orchestration

### DIFF
--- a/app/Console/Commands/DataImport.php
+++ b/app/Console/Commands/DataImport.php
@@ -2,9 +2,9 @@
 
 namespace App\Console\Commands;
 
+use App\Support\SeederRegistry;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Container\BindingResolutionException;
-use Database\Seeders\DatabaseSeeder;
 use Database\Seeders\DemoDataSeeder;
 
 class DataImport extends Command
@@ -30,10 +30,8 @@ class DataImport extends Command
     {
         $this->info('Starting data import...');
 
-        $seeders = [
-            DatabaseSeeder::class => 'Base application seeders',
-            DemoDataSeeder::class => 'Comprehensive multilingual demo data',
-        ];
+        $seeders = SeederRegistry::baseSeeders();
+        $seeders[DemoDataSeeder::class] = 'Comprehensive multilingual demo data';
 
         foreach ($seeders as $seeder => $description) {
             $this->info("Seeding: {$description}...");

--- a/app/Http/Controllers/Admin/AttributeController.php
+++ b/app/Http/Controllers/Admin/AttributeController.php
@@ -7,7 +7,8 @@ use App\Models\Attribute;
 use App\Models\Language;
 use App\Services\Admin\AttributeService;
 use Illuminate\Http\Request;
-use Yajra\DataTables\Facades\DataTables;
+use Illuminate\Http\Response;
+use Throwable;
 
 class AttributeController extends Controller
 {
@@ -23,26 +24,6 @@ class AttributeController extends Controller
         $attributes = $this->attributeService->getAllAttributes();
 
         return view('admin.attributes.index', compact('attributes'));
-    }
-
-    public function getAttributesData(Request $request)
-    {
-        if ($request->ajax()) {
-            $attributes = Attribute::with('values')->get();
-
-            return DataTables::of($attributes)
-                ->addColumn('values', function ($attribute) {
-                    return $attribute->values->map(function ($value) {
-                        return '<span class="badge bg-primary">'.e($value->value).'</span>';
-                    })->implode(' ');
-                })
-                ->addColumn('action', function ($attribute) {
-                    return '<a href="'.route('admin.attributes.edit', $attribute->id).'" class="btn btn-sm btn-warning">Edit</a>
-                            <button class="btn btn-sm btn-danger" onclick="deleteAttribute('.$attribute->id.')">Delete</button>';
-                })
-                ->rawColumns(['values', 'action'])
-                ->make(true);
-        }
     }
 
     public function create()
@@ -104,14 +85,32 @@ class AttributeController extends Controller
         return redirect()->route('admin.attributes.index')->with('success', __('cms.attributes.success_update'));
     }
 
-    public function destroy($id)
+    public function destroy(Request $request, Attribute $attribute)
     {
         try {
-            $this->attributeService->deleteAttribute($id);
+            $this->attributeService->deleteAttribute($attribute->id);
 
-            return response()->json(['success' => true, 'message' => __('cms.attributes.success_delete')]);
-        } catch (\Exception $e) {
-            return response()->json(['success' => false, 'message' => 'Error deleting attribute! Please try again.']);
+            if ($request->wantsJson()) {
+                return response()->json([
+                    'success' => true,
+                    'message' => __('cms.attributes.success_delete'),
+                ]);
+            }
+
+            return redirect()
+                ->route('admin.attributes.index')
+                ->with('success', __('cms.attributes.success_delete'));
+        } catch (Throwable $e) {
+            if ($request->wantsJson()) {
+                return response()->json([
+                    'success' => false,
+                    'message' => __('cms.attributes.error_delete'),
+                ], Response::HTTP_INTERNAL_SERVER_ERROR);
+            }
+
+            return redirect()
+                ->route('admin.attributes.index')
+                ->with('error', __('cms.attributes.error_delete'));
         }
     }
 }

--- a/app/Support/SeederRegistry.php
+++ b/app/Support/SeederRegistry.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Support;
+
+class SeederRegistry
+{
+    /**
+     * Base seeders required for the application demo data.
+     *
+     * @return array<string, string>
+     */
+    public static function baseSeeders(): array
+    {
+        return [
+            \Database\Seeders\LanguageSeeder::class => 'Languages',
+            \Database\Seeders\ProductVariantLocaleSeeder::class => 'Product variant locales',
+            \Database\Seeders\CurrencySeeder::class => 'Currencies',
+            \Database\Seeders\AttributeSeeder::class => 'Core attributes',
+            \Database\Seeders\BrandSeeder::class => 'Brands',
+            \Database\Seeders\CategorySeeder::class => 'Categories',
+            \Database\Seeders\MenuSeeder::class => 'Menus',
+            \Database\Seeders\BannerSeeder::class => 'Banners',
+            \Database\Seeders\PageSeeder::class => 'Pages',
+            \Database\Seeders\SiteSettingsSeeder::class => 'Site settings',
+            \Database\Seeders\PaymentGatewaySeeder::class => 'Payment gateways',
+            \Database\Seeders\PaymentGatewayConfigSeeder::class => 'Payment gateway configurations',
+            \Database\Seeders\VendorSeeder::class => 'Vendors',
+            \Database\Seeders\ProductSeeder::class => 'Products',
+            \Database\Seeders\ProductVariantDemoSeeder::class => 'Product variants',
+            \Database\Seeders\CouponSeeder::class => 'Coupons',
+            \Database\Seeders\CustomerSeeder::class => 'Customers',
+            \Database\Seeders\CustomerAddressSeeder::class => 'Customer addresses',
+            \Database\Seeders\OrderSeeder::class => 'Sample orders',
+            \Database\Seeders\CustomerOrderSeeder::class => 'Customer order history',
+            \Database\Seeders\PaymentSeeder::class => 'Payments',
+            \Database\Seeders\RefundSeeder::class => 'Refunds',
+            \Database\Seeders\ProductReviewSeeder::class => 'Product reviews',
+        ];
+    }
+}

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,7 +2,7 @@
 
 namespace Database\Seeders;
 
-// use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use App\Support\SeederRegistry;
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder
@@ -12,23 +12,8 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        $this->call([
-            LanguageSeeder::class,
-            BannerSeeder::class,
-            PageSeeder::class,
-            ProductVariantLocaleSeeder::class,
-            CurrencySeeder::class,
-            VendorSeeder::class,
-            ProductSeeder::class,
-            ProductReviewSeeder::class,
-            CouponSeeder::class,
-            OrderSeeder::class,
-            PaymentGatewaySeeder::class,
-            PaymentSeeder::class,
-            RefundSeeder::class,
-            CustomerSeeder::class,
-            CustomerAddressSeeder::class,
-            ProductVariantDemoSeeder::class,
-        ]);
+        foreach (SeederRegistry::baseSeeders() as $seeder => $description) {
+            $this->call($seeder);
+        }
     }
 }

--- a/lang/en/cms.php
+++ b/lang/en/cms.php
@@ -1335,11 +1335,19 @@ return [
         'title_create' => 'Create Attribute',
         'title_edit' => 'Edit Attribute',
         'title_manage' => 'Manage Attributes',
+        'index_description' => 'Browse and manage attribute definitions for your catalogue.',
 
         'attribute_name' => 'Attribute Name',
+        'attribute_name_placeholder' => 'Size, Material, Fabric...',
         'attribute_values' => 'Attribute Values',
+        'attribute_values_help' => 'Define the options customers can choose from. Add translations to localise labels.',
         'translations' => 'Translations',
         'translated_value' => 'Translated Value',
+
+        'value_label' => 'Value #:number',
+        'value_placeholder' => 'Value #:number',
+        'translation_label' => 'Translation (:language)',
+        'translation_placeholder' => 'Translation (:language)',
 
         'add_value' => 'Add Value',
         'remove_value' => 'Remove',
@@ -1350,13 +1358,16 @@ return [
         'success_create' => 'Attribute created successfully!',
         'success_update' => 'Attribute updated successfully!',
         'success_delete' => 'Attribute deleted successfully!',
+        'error_delete' => 'Error deleting attribute! Please try again.',
         'delete_confirmation' => 'Are you sure you want to delete this attribute?',
         'success' => 'Success',
 
         'id' => 'ID',
         'name' => 'Name',
         'values' => 'Values',
+        'no_values' => 'No values defined',
         'action' => 'Action',
+        'empty_state' => 'No attributes have been created yet.',
 
         'confirm_delete' => 'Confirm Delete',
         'delete' => 'Delete',

--- a/resources/views/admin/attributes/index.blade.php
+++ b/resources/views/admin/attributes/index.blade.php
@@ -3,155 +3,65 @@
 @section('title', __('cms.attributes.title_manage'))
 
 @section('content')
-<x-admin.page-header :title="__('cms.attributes.title_manage')">
+<x-admin.page-header :title="__('cms.attributes.title_manage')" :description="__('cms.attributes.index_description')">
     <x-admin.button-link href="{{ route('admin.attributes.create') }}" class="btn-primary">
         {{ __('cms.attributes.title_create') }}
     </x-admin.button-link>
 </x-admin.page-header>
 
 <x-admin.card class="mt-6">
-    <x-admin.table id="attributes-table" :columns="[
-        __('cms.attributes.id'),
-        __('cms.attributes.name'),
-        __('cms.attributes.values'),
-        __('cms.attributes.action'),
-    ]">
-    </x-admin.table>
-</x-admin.card>
-
-<div class="modal fade" id="deleteAttributeModal" tabindex="-1" aria-labelledby="deleteAttributeModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="deleteAttributeModalLabel">{{ __('cms.attributes.confirm_delete') }}</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">{{ __('cms.attributes.delete_confirmation') }}</div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">{{ __('cms.attributes.cancel') }}</button>
-                <button type="button" class="btn btn-danger" id="confirmDeleteAttribute">{{ __('cms.attributes.delete') }}</button>
-            </div>
-        </div>
+    <div class="table-responsive">
+        <table class="table align-middle">
+            <thead>
+                <tr>
+                    <th scope="col" class="w-16">{{ __('cms.attributes.id') }}</th>
+                    <th scope="col">{{ __('cms.attributes.name') }}</th>
+                    <th scope="col" class="w-1/2">{{ __('cms.attributes.values') }}</th>
+                    <th scope="col" class="text-end">{{ __('cms.attributes.action') }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                @forelse ($attributes as $attribute)
+                    <tr>
+                        <td>{{ $attribute->id }}</td>
+                        <td class="fw-semibold">{{ $attribute->name }}</td>
+                        <td>
+                            <div class="d-flex flex-wrap gap-2">
+                                @forelse ($attribute->values as $value)
+                                    <span class="badge bg-primary">{{ $value->value }}</span>
+                                @empty
+                                    <span class="text-muted">{{ __('cms.attributes.no_values') }}</span>
+                                @endforelse
+                            </div>
+                        </td>
+                        <td class="text-end">
+                            <div class="d-inline-flex gap-2">
+                                <a href="{{ route('admin.attributes.edit', $attribute) }}" class="btn btn-outline-primary btn-sm">
+                                    {{ __('cms.attributes.title_edit') }}
+                                </a>
+                                <form action="{{ route('admin.attributes.destroy', $attribute) }}" method="POST" class="d-inline">
+                                    @csrf
+                                    @method('DELETE')
+                                    <button type="submit" class="btn btn-outline-danger btn-sm" onclick="return confirm('{{ __('cms.attributes.confirm_delete') }}');">
+                                        {{ __('cms.attributes.delete') }}
+                                    </button>
+                                </form>
+                            </div>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="4" class="text-center py-4 text-muted">
+                            {{ __('cms.attributes.empty_state') }}
+                        </td>
+                    </tr>
+                @endforelse
+            </tbody>
+        </table>
     </div>
-</div>
-@endsection
 
-@php
-    $datatableLang = __('cms.datatables');
-@endphp
-
-@section('js')
-    <script>
-        document.addEventListener('DOMContentLoaded', () => {
-            const table = $('#attributes-table').DataTable({
-                processing: true,
-                serverSide: true,
-                ajax: {
-                    url: "{{ route('admin.attributes.data') }}",
-                    type: 'POST',
-                    data: function (data) {
-                        data._token = "{{ csrf_token() }}";
-                    },
-                },
-                columns: [
-                    { data: 'id', name: 'id' },
-                    { data: 'name', name: 'name' },
-                    { data: 'values', name: 'values', orderable: false, searchable: false },
-                    {
-                        data: 'action',
-                        orderable: false,
-                        searchable: false,
-                        render: function (data, type, row) {
-                            const editUrl = "{{ route('admin.attributes.edit', ':id') }}".replace(':id', row.id);
-
-                            return `
-                                <div class="flex items-center gap-2">
-                                    <button type="button" class="btn btn-outline-primary btn-sm btn-edit-attribute" data-url="${editUrl}" aria-label="{{ __('cms.attributes.title_edit') }}">
-                                        <i class="bi bi-pencil-fill" aria-hidden="true"></i>
-                                    </button>
-                                    <button type="button" class="btn btn-outline-danger btn-sm btn-delete-attribute" data-id="${row.id}" aria-label="{{ __('cms.attributes.delete') }}">
-                                        <i class="bi bi-trash-fill" aria-hidden="true"></i>
-                                    </button>
-                                </div>
-                            `;
-                        },
-                    },
-                ],
-                pageLength: 10,
-                language: @json($datatableLang),
-            });
-
-            let attributeToDeleteId = null;
-            const deleteModalElement = document.getElementById('deleteAttributeModal');
-            const deleteModal = deleteModalElement ? new bootstrap.Modal(deleteModalElement) : null;
-            const confirmDeleteButton = document.getElementById('confirmDeleteAttribute');
-
-            $(document).on('click', '.btn-edit-attribute', function () {
-                const url = $(this).data('url');
-                if (url) {
-                    window.location.href = url;
-                }
-            });
-
-            $(document).on('click', '.btn-delete-attribute', function () {
-                attributeToDeleteId = $(this).data('id') ?? null;
-                if (deleteModal) {
-                    deleteModal.show();
-                }
-            });
-
-            if (confirmDeleteButton) {
-                confirmDeleteButton.addEventListener('click', () => {
-                    if (!attributeToDeleteId) {
-                        return;
-                    }
-
-                    $.ajax({
-                        url: '{{ route('admin.attributes.destroy', ':id') }}'.replace(':id', attributeToDeleteId),
-                        method: 'DELETE',
-                        data: {
-                            _token: '{{ csrf_token() }}',
-                        },
-                        success: function (response) {
-                            if (response.success) {
-                                table.ajax.reload(null, false);
-                                toastr.success(response.message, "{{ __('cms.attributes.success') }}", {
-                                    closeButton: true,
-                                    progressBar: true,
-                                    positionClass: 'toast-top-right',
-                                    timeOut: 5000,
-                                });
-                                attributeToDeleteId = null;
-                                if (deleteModal) {
-                                    deleteModal.hide();
-                                }
-                            } else {
-                                const message = response.message || 'Error deleting attribute! Please try again.';
-                                toastr.error(message, "{{ __('cms.attributes.confirm_delete') }}", {
-                                    closeButton: true,
-                                    progressBar: true,
-                                    positionClass: 'toast-top-right',
-                                    timeOut: 5000,
-                                });
-                            }
-                        },
-                        error: function () {
-                            toastr.error('Error deleting attribute! Please try again.', 'Error', {
-                                closeButton: true,
-                                progressBar: true,
-                                positionClass: 'toast-top-right',
-                                timeOut: 5000,
-                            });
-                        },
-                    });
-                });
-            }
-
-            if (deleteModalElement) {
-                deleteModalElement.addEventListener('hidden.bs.modal', () => {
-                    attributeToDeleteId = null;
-                });
-            }
-        });
-    </script>
+    <div class="mt-3">
+        {{ $attributes->links() }}
+    </div>
+</x-admin.card>
 @endsection

--- a/resources/views/admin/attributes/partials/form-scripts.blade.php
+++ b/resources/views/admin/attributes/partials/form-scripts.blade.php
@@ -8,168 +8,120 @@
 <script>
     document.addEventListener('DOMContentLoaded', () => {
         const languages = @json($languageMeta);
-        const valueContainer = document.getElementById('attribute-values-container');
+        const container = document.getElementById('attribute-values-container');
         const addButton = document.getElementById('add-attribute-value');
-        const tabTriggers = Array.from(document.querySelectorAll('[data-language-tab-target]'));
-        const tabPanels = Array.from(document.querySelectorAll('[data-language-panel]'));
-        const removeText = @json(__('cms.attributes.remove_value'));
-        const valuePlaceholder = @json(__('cms.attributes.attribute_values'));
-        const translationPlaceholder = @json(__('cms.attributes.translated_value'));
 
-        if (!valueContainer) {
+        if (!container || !addButton) {
             return;
         }
 
-        const generateRowId = () => `attribute-value-${Date.now()}-${Math.floor(Math.random() * 10000)}`;
+        const removeText = @json(__('cms.attributes.remove_value'));
+        const valueLabelTemplate = @json(__('cms.attributes.value_label', ['number' => ':number']));
+        const valuePlaceholderTemplate = @json(__('cms.attributes.value_placeholder', ['number' => ':number']));
+        const translationLabelTemplate = @json(__('cms.attributes.translation_label', ['language' => ':language']));
+        const translationPlaceholderTemplate = @json(__('cms.attributes.translation_placeholder', ['language' => ':language']));
 
-        const updatePlaceholders = () => {
-            const rows = Array.from(valueContainer.querySelectorAll('.attribute-value-row'));
+        const escapeHtml = (value) => {
+            if (typeof value !== 'string') {
+                return '';
+            }
+
+            return value
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        };
+
+        const createRow = (value = '', translationValues = {}) => {
+            const row = document.createElement('div');
+            row.className = 'attribute-value-row rounded border border-gray-200 p-4';
+
+            const translationsMarkup = languages.map(({ code }) => `
+                <div class="col-12 col-md-6 col-lg-4">
+                    <label class="form-label" data-translation-label data-language="${code}"></label>
+                    <input
+                        type="text"
+                        name="translations[${code}][]"
+                        value="${escapeHtml(translationValues[code] ?? '')}"
+                        class="form-control"
+                    >
+                </div>
+            `).join('');
+
+            row.innerHTML = `
+                <div class="row g-3 align-items-end">
+                    <div class="col-12 col-md-6 col-lg-5">
+                        <label class="form-label" data-value-label></label>
+                        <input type="text" name="values[]" value="${escapeHtml(value)}" class="form-control">
+                    </div>
+                    <div class="col-12 col-md-6 col-lg-4 d-flex gap-2">
+                        <button type="button" class="btn btn-outline-danger attribute-value-remove">${removeText}</button>
+                    </div>
+                </div>
+                <div class="row g-3 mt-1">
+                    ${translationsMarkup}
+                </div>
+            `;
+
+            return row;
+        };
+
+        const updateRowLabels = () => {
+            const rows = Array.from(container.querySelectorAll('.attribute-value-row'));
 
             rows.forEach((row, index) => {
-                const baseInput = row.querySelector('input[name="values[]"]');
-                if (baseInput) {
-                    baseInput.placeholder = `${valuePlaceholder} #${index + 1}`;
+                const valueLabel = row.querySelector('[data-value-label]');
+                const valueInput = row.querySelector('input[name="values[]"]');
+
+                if (valueLabel) {
+                    valueLabel.textContent = valueLabelTemplate.replace(':number', index + 1);
                 }
 
-                languages.forEach(({ code, name }) => {
-                    const translationInput = row.querySelector(`input[name="translations[${code}][]"]`);
-                    if (translationInput) {
-                        translationInput.placeholder = `${translationPlaceholder} (${name}) #${index + 1}`;
+                if (valueInput) {
+                    valueInput.placeholder = valuePlaceholderTemplate.replace(':number', index + 1);
+                }
+
+                row.querySelectorAll('[data-translation-label]').forEach((label) => {
+                    const languageCode = label.getAttribute('data-language');
+                    const languageName = languages.find((language) => language.code === languageCode)?.name ?? languageCode.toUpperCase();
+
+                    label.textContent = translationLabelTemplate.replace(':language', languageName);
+
+                    const input = label.nextElementSibling;
+                    if (input && input.tagName === 'INPUT') {
+                        input.placeholder = translationPlaceholderTemplate.replace(':language', languageName);
                     }
                 });
             });
         };
 
-        const activateFirstTab = (row) => {
-            const firstTabTrigger = row.querySelector('.attribute-language-tabs button');
-            if (firstTabTrigger && typeof bootstrap !== 'undefined') {
-                bootstrap.Tab.getOrCreateInstance(firstTabTrigger).show();
-            }
-        };
-
-        const createRow = (value = '', translationValues = {}) => {
-            const row = document.createElement('div');
-            row.className = 'attribute-value-row space-y-4 rounded-lg border border-gray-200 p-4';
-
-            const rowId = generateRowId();
-            row.dataset.rowId = rowId;
-
-            const header = document.createElement('div');
-            header.className = 'flex flex-col gap-2 md:flex-row md:items-start md:gap-3';
-
-            const inputWrapper = document.createElement('div');
-            inputWrapper.className = 'flex-1';
-
-            const input = document.createElement('input');
-            input.type = 'text';
-            input.name = 'values[]';
-            input.value = value || '';
-            input.className = 'form-control';
-
-            inputWrapper.appendChild(input);
-            header.appendChild(inputWrapper);
-
-            const removeButton = document.createElement('button');
-            removeButton.type = 'button';
-            removeButton.className = 'btn btn-outline-danger attribute-value-remove self-start';
-            removeButton.textContent = removeText;
-
-            header.appendChild(removeButton);
-            row.appendChild(header);
-
-            const translationWrapper = document.createElement('div');
-            translationWrapper.className = 'translation-section';
-
-            const navTabs = document.createElement('ul');
-            navTabs.className = 'nav nav-tabs attribute-language-tabs';
-            navTabs.id = `${rowId}-tabs`;
-            navTabs.setAttribute('role', 'tablist');
-
-            const tabContent = document.createElement('div');
-            tabContent.className = 'tab-content mt-3';
-            tabContent.id = `${rowId}-tab-content`;
-
-            languages.forEach(({ code, name }, index) => {
-                const tabId = `${rowId}-${code}-tab`;
-                const paneId = `${rowId}-${code}-panel`;
-
-                const listItem = document.createElement('li');
-                listItem.className = 'nav-item';
-                listItem.setAttribute('role', 'presentation');
-
-                const tabButton = document.createElement('button');
-                tabButton.type = 'button';
-                tabButton.className = `nav-link${index === 0 ? ' active' : ''}`;
-                tabButton.id = tabId;
-                tabButton.dataset.bsToggle = 'tab';
-                tabButton.dataset.bsTarget = `#${paneId}`;
-                tabButton.setAttribute('role', 'tab');
-                tabButton.setAttribute('aria-controls', paneId);
-                tabButton.setAttribute('aria-selected', index === 0 ? 'true' : 'false');
-                tabButton.textContent = name;
-
-                listItem.appendChild(tabButton);
-                navTabs.appendChild(listItem);
-
-                const tabPane = document.createElement('div');
-                tabPane.className = `tab-pane fade show${index === 0 ? ' active' : ''}`;
-                tabPane.id = paneId;
-                tabPane.setAttribute('role', 'tabpanel');
-                tabPane.setAttribute('aria-labelledby', tabId);
-
-                const translationInput = document.createElement('input');
-                translationInput.type = 'text';
-                translationInput.name = `translations[${code}][]`;
-                translationInput.value = translationValues[code] ?? '';
-                translationInput.className = 'form-control';
-
-                tabPane.appendChild(translationInput);
-                tabContent.appendChild(tabPane);
-            });
-
-            translationWrapper.appendChild(navTabs);
-            translationWrapper.appendChild(tabContent);
-            row.appendChild(translationWrapper);
-
-            return row;
-        };
-
         const addValueRow = (value = '', translationValues = {}) => {
             const row = createRow(value, translationValues);
-            valueContainer.appendChild(row);
-            updatePlaceholders();
-            activateFirstTab(row);
+            container.appendChild(row);
+            updateRowLabels();
         };
 
-        const clearSingleRow = (row) => {
-            const valueInput = row.querySelector('input[name="values[]"]');
-            if (valueInput) {
-                valueInput.value = '';
-            }
-
-            languages.forEach(({ code }) => {
-                const translationInput = row.querySelector(`input[name="translations[${code}][]"]`);
-                if (translationInput) {
-                    translationInput.value = '';
-                }
+        const clearRowValues = (row) => {
+            row.querySelectorAll('input').forEach((input) => {
+                input.value = '';
             });
-
-            activateFirstTab(row);
-            updatePlaceholders();
         };
 
         const removeValueRow = (row) => {
-            const rows = Array.from(valueContainer.querySelectorAll('.attribute-value-row'));
+            const rows = container.querySelectorAll('.attribute-value-row');
+
             if (rows.length <= 1) {
-                clearSingleRow(row);
+                clearRowValues(row);
                 return;
             }
 
             row.remove();
-            updatePlaceholders();
+            updateRowLabels();
         };
 
-        valueContainer.addEventListener('click', (event) => {
+        container.addEventListener('click', (event) => {
             const trigger = event.target.closest('.attribute-value-remove');
             if (!trigger) {
                 return;
@@ -182,31 +134,14 @@
             }
         });
 
-        if (addButton) {
-            addButton.addEventListener('click', () => {
-                addValueRow();
-            });
-        }
+        addButton.addEventListener('click', () => {
+            addValueRow();
+        });
 
-        if (valueContainer.querySelectorAll('.attribute-value-row').length === 0) {
+        if (container.querySelectorAll('.attribute-value-row').length === 0) {
             addValueRow();
         } else {
-            updatePlaceholders();
-            valueContainer.querySelectorAll('.attribute-value-row').forEach((row) => activateFirstTab(row));
+            updateRowLabels();
         }
-
-        @if ($errors->any())
-            const firstInvalid = document.querySelector('.is-invalid');
-            if (firstInvalid) {
-                const tabPane = firstInvalid.closest('[data-language-panel]');
-                if (tabPane) {
-                    const code = tabPane.dataset.languagePanel;
-                    const trigger = document.querySelector(`[data-language-tab-target="${code}"]`);
-                    if (trigger) {
-                        setActiveTab(code);
-                    }
-                }
-            }
-        @endif
     });
 </script>

--- a/resources/views/admin/attributes/partials/form.blade.php
+++ b/resources/views/admin/attributes/partials/form.blade.php
@@ -2,14 +2,10 @@
     $isEdit = isset($attribute);
 
     $values = old('values');
-    if (is_array($values)) {
-        $values = array_values($values);
-    } elseif ($isEdit) {
-        $values = $attribute->values->pluck('value')->toArray();
-    } else {
-        $values = [];
+    if (! is_array($values)) {
+        $values = $isEdit ? $attribute->values->pluck('value')->toArray() : [];
     }
-
+    $values = array_values(array_filter($values, fn ($value) => $value !== null));
     if (empty($values)) {
         $values = [''];
     }
@@ -19,21 +15,17 @@
         $code = $language->code;
         $languageTranslations = old("translations.{$code}");
 
-        if (is_array($languageTranslations)) {
-            $languageTranslations = array_values($languageTranslations);
-        } elseif ($isEdit) {
+        if (! is_array($languageTranslations) && $isEdit) {
             $languageTranslations = $attribute->values->map(function ($value) use ($code) {
                 return optional($value->translations->firstWhere('language_code', $code))->translated_value ?? '';
             })->toArray();
-        } else {
+        }
+
+        if (! is_array($languageTranslations)) {
             $languageTranslations = [];
         }
 
-        if (count($languageTranslations) > count($values)) {
-            $languageTranslations = array_slice($languageTranslations, 0, count($values));
-        }
-
-        $translations[$code] = array_pad($languageTranslations, count($values), '');
+        $translations[$code] = array_pad(array_values($languageTranslations), count($values), '');
     }
 
     $formMethod = strtoupper($method ?? 'POST');
@@ -46,8 +38,8 @@
     @endif
 
     <x-admin.card :title="__('cms.attributes.attribute_name')">
-        <div class="grid gap-4 md:grid-cols-2">
-            <div class="md:col-span-2">
+        <div class="row g-4">
+            <div class="col-12 col-lg-8">
                 <label for="name" class="form-label">{{ __('cms.attributes.attribute_name') }}</label>
                 <input
                     type="text"
@@ -55,6 +47,7 @@
                     id="name"
                     value="{{ old('name', $attribute->name ?? '') }}"
                     class="form-control @error('name') is-invalid @enderror"
+                    placeholder="{{ __('cms.attributes.attribute_name_placeholder') }}"
                 >
                 @error('name')
                     <div class="invalid-feedback d-block">{{ $message }}</div>
@@ -63,76 +56,53 @@
         </div>
     </x-admin.card>
 
-    <x-admin.card :title="__('cms.attributes.attribute_values')">
+    <x-admin.card :title="__('cms.attributes.attribute_values')" :description="__('cms.attributes.attribute_values_help')">
         <div id="attribute-values-container" class="space-y-4">
             @foreach ($values as $index => $value)
-                @php
-                    $rowId = 'attribute-value-row-' . $index;
-                @endphp
-                <div class="attribute-value-row space-y-4 rounded-lg border border-gray-200 p-4" data-row-id="{{ $rowId }}">
-                    <div class="flex flex-col gap-2 md:flex-row md:items-start md:gap-3">
-                        <div class="flex-1">
+                <div class="attribute-value-row rounded border border-gray-200 p-4">
+                    <div class="row g-3 align-items-end">
+                        <div class="col-12 col-md-6 col-lg-5">
+                            <label class="form-label" data-value-label>{{ __('cms.attributes.value_label', ['number' => $loop->iteration]) }}</label>
                             <input
                                 type="text"
                                 name="values[]"
                                 value="{{ $value }}"
                                 class="form-control @error('values.' . $index) is-invalid @enderror"
+                                placeholder="{{ __('cms.attributes.value_placeholder', ['number' => $loop->iteration]) }}"
                             >
                             @error('values.' . $index)
                                 <div class="invalid-feedback d-block">{{ $message }}</div>
                             @enderror
                         </div>
-                        <button type="button" class="btn btn-outline-danger attribute-value-remove self-start">
-                            {{ __('cms.attributes.remove_value') }}
-                        </button>
+                        <div class="col-12 col-md-6 col-lg-4 d-flex gap-2">
+                            <button type="button" class="btn btn-outline-danger attribute-value-remove">
+                                {{ __('cms.attributes.remove_value') }}
+                            </button>
+                        </div>
                     </div>
 
-                    <div class="translation-section">
-                        <ul class="nav nav-tabs attribute-language-tabs" id="{{ $rowId }}-tabs" role="tablist">
-                            @foreach ($languages as $language)
-                                @php
-                                    $code = $language->code;
-                                @endphp
-                                <li class="nav-item" role="presentation">
-                                    <button
-                                        class="nav-link {{ $loop->first ? 'active' : '' }}"
-                                        id="{{ $rowId }}-{{ $code }}-tab"
-                                        data-bs-toggle="tab"
-                                        data-bs-target="#{{ $rowId }}-{{ $code }}-panel"
-                                        type="button"
-                                        role="tab"
-                                        aria-controls="{{ $rowId }}-{{ $code }}-panel"
-                                        aria-selected="{{ $loop->first ? 'true' : 'false' }}"
-                                    >
-                                        {{ ucwords($language->name) }}
-                                    </button>
-                                </li>
-                            @endforeach
-                        </ul>
-                        <div class="tab-content mt-3" id="{{ $rowId }}-tab-content">
-                            @foreach ($languages as $language)
-                                @php
-                                    $code = $language->code;
-                                    $translationValue = $translations[$code][$index] ?? '';
-                                @endphp
-                                <div
-                                    class="tab-pane fade show {{ $loop->first ? 'active' : '' }}"
-                                    id="{{ $rowId }}-{{ $code }}-panel"
-                                    role="tabpanel"
-                                    aria-labelledby="{{ $rowId }}-{{ $code }}-tab"
+                    <div class="row g-3 mt-1">
+                        @foreach ($languages as $language)
+                            @php
+                                $code = $language->code;
+                                $translationValue = $translations[$code][$index] ?? '';
+                            @endphp
+                            <div class="col-12 col-md-6 col-lg-4">
+                                <label class="form-label" data-translation-label data-language="{{ $code }}">
+                                    {{ __('cms.attributes.translation_label', ['language' => ucwords($language->name)]) }}
+                                </label>
+                                <input
+                                    type="text"
+                                    name="translations[{{ $code }}][]"
+                                    value="{{ $translationValue }}"
+                                    class="form-control @error('translations.' . $code . '.' . $index) is-invalid @enderror"
+                                    placeholder="{{ __('cms.attributes.translation_placeholder', ['language' => ucwords($language->name)]) }}"
                                 >
-                                    <input
-                                        type="text"
-                                        name="translations[{{ $code }}][]"
-                                        value="{{ $translationValue }}"
-                                        class="form-control @error('translations.' . $code . '.' . $index) is-invalid @enderror"
-                                    >
-                                    @error('translations.' . $code . '.' . $index)
-                                        <div class="invalid-feedback d-block">{{ $message }}</div>
-                                    @enderror
-                                </div>
-                            @endforeach
-                        </div>
+                                @error('translations.' . $code . '.' . $index)
+                                    <div class="invalid-feedback d-block">{{ $message }}</div>
+                                @enderror
+                            </div>
+                        @endforeach
                     </div>
                 </div>
             @endforeach
@@ -142,7 +112,7 @@
         </button>
     </x-admin.card>
 
-    <div class="flex flex-col-reverse gap-3 md:flex-row md:items-center md:justify-end">
+    <div class="d-flex flex-column flex-md-row gap-3 justify-content-end">
         <x-admin.button-link href="{{ route('admin.attributes.index') }}" class="btn-outline">
             {{ __('cms.attributes.cancel') }}
         </x-admin.button-link>

--- a/routes/web.php
+++ b/routes/web.php
@@ -116,7 +116,6 @@ Route::prefix('admin')->name('admin.')->group(function () {
     /* Attribute Value Management */
     Route::post('attributes/{attribute}/values', [AttributeController::class, 'storeValue'])->name('attributes.values.store');
     Route::delete('values/{value}', [AttributeController::class, 'destroyValue'])->name('values.destroy');
-    Route::post('attributes/data', [AttributeController::class, 'getAttributesData'])->name('attributes.data');
 
     /* Attribute Value Translations Management */
     Route::post('values/{value}/translations', [AttributeController::class, 'storeTranslation'])->name('values.translations.store');


### PR DESCRIPTION
## Summary
- replace the admin attributes DataTable with a paginated table and refresh the create/edit form UX and scripts
- update the attribute controller and routes to drop the AJAX endpoint and support standard delete redirects with new copy
- centralize the base seeder list via a SeederRegistry that is shared by DatabaseSeeder and the data:import command

## Testing
- php artisan test *(fails: vendor/autoload.php is missing in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df94252cdc8329b1bcfc34c4f21111