### PR TITLE
Enhance admin refund management and seeding

### DIFF
--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -19,6 +19,7 @@ class DatabaseSeeder extends Seeder
             ProductVariantLocaleSeeder::class,
             CurrencySeeder::class,
             VendorSeeder::class,
+            ShopSeeder::class,
             ProductSeeder::class,
             ProductReviewSeeder::class,
             CouponSeeder::class,

--- a/database/seeders/ShopSeeder.php
+++ b/database/seeders/ShopSeeder.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Shop;
+use App\Models\Vendor;
+use Illuminate\Database\Seeder;
+
+class ShopSeeder extends Seeder
+{
+    public function run(): void
+    {
+        $vendor = Vendor::query()->orderBy('id')->first()
+            ?? Vendor::factory()->create([
+                'status' => 'active',
+            ]);
+
+        $shops = [
+            [
+                'name' => 'Urban Threads',
+                'slug' => 'urban-threads',
+                'description' => 'Streetwear essentials and lifestyle picks.',
+            ],
+            [
+                'name' => 'Nordic Living',
+                'slug' => 'nordic-living',
+                'description' => 'Scandinavian-inspired home and decor.',
+            ],
+            [
+                'name' => 'Pulse Electronics',
+                'slug' => 'pulse-electronics',
+                'description' => 'Gadgets, accessories, and smart devices.',
+            ],
+        ];
+
+        foreach ($shops as $data) {
+            Shop::updateOrCreate(
+                ['slug' => $data['slug']],
+                [
+                    'vendor_id' => $vendor->id,
+                    'name' => $data['name'],
+                    'description' => $data['description'],
+                    'status' => 'active',
+                    'logo' => $data['logo'] ?? null,
+                ]
+            );
+        }
+
+        // Ensure there is always at least one default shop for products
+        if (! Shop::query()->where('slug', 'default-shop')->exists()) {
+            Shop::firstOrCreate(
+                ['slug' => 'default-shop'],
+                [
+                    'vendor_id' => $vendor->id,
+                    'name' => 'Default Shop',
+                    'description' => 'Auto-generated default shop for catalog seeding.',
+                    'status' => 'active',
+                ]
+            );
+        }
+    }
+}

--- a/lang/en/cms.php
+++ b/lang/en/cms.php
@@ -242,6 +242,9 @@ return [
         'status' => 'Status',
         'reason' => 'Reason',
         'action' => 'Action',
+        'reference' => 'Reference',
+        'shop_column' => 'Shop',
+        'customer_column' => 'Customer',
 
         // Status Labels
         'completed' => 'Completed',
@@ -264,11 +267,25 @@ return [
         'date_to_label' => 'To date',
         'apply_filters' => 'Apply filters',
         'reset_filters' => 'Reset filters',
+        'shop_filter_label' => 'Shop',
+        'shop_filter_placeholder' => 'All shops',
+        'gateway_filter_label' => 'Payment gateway',
+        'gateway_filter_placeholder' => 'All gateways',
+        'search_filter_label' => 'Search',
+        'search_filter_placeholder' => 'Search by refund ID, order, payment, or customer',
 
         // Summary Cards
         'summary_total_count' => 'Total refunds',
         'summary_completed_count' => 'Completed refunds',
         'summary_total_amount' => 'Total refunded',
+        'summary_pending_count' => 'Open refunds',
+        'summary_average_amount' => 'Average refund value',
+
+        // Shop Insights
+        'shop_breakdown_title' => 'Refunds by shop',
+        'shop_breakdown_help' => 'Top shops ranked by completed refund amount.',
+        'shop_breakdown_empty' => 'No shops have recorded refunds yet.',
+        'shop_breakdown_count' => '{0} No refunds|{1} :count refund|[2,*] :count refunds',
 
         // Delete Modal
         'delete_confirm' => 'Confirm Delete',
@@ -285,6 +302,18 @@ return [
         'created_at' => 'Created At',
         'updated_at' => 'Updated At',
         'back' => 'Back to Refunds',
+        'payment_summary_title' => 'Payment summary',
+        'gateway_summary_title' => 'Payment gateway',
+        'order_number' => 'Order',
+        'view_order' => 'View order',
+        'customer_summary_title' => 'Customer details',
+        'payment_status_label' => 'Payment status',
+        'items_summary_title' => 'Items in this order',
+        'item_line' => 'Qty :quantity · :price',
+        'timeline_title' => 'Refund timeline',
+        'timeline_created' => 'Requested on',
+        'timeline_updated' => 'Last updated on',
+        'timeline_status' => 'Current status',
 
         // Fallback
         'not_available' => 'N/A',

--- a/resources/views/admin/refunds/index.blade.php
+++ b/resources/views/admin/refunds/index.blade.php
@@ -9,7 +9,7 @@
         </div>
     </div>
 
-    <div class="grid gap-4 md:grid-cols-3">
+    <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4">
         <div class="rounded-2xl border border-primary-100 bg-primary-50 px-6 py-5">
             <p class="text-xs font-semibold uppercase tracking-wide text-primary-600">{{ __('cms.refunds.summary_total_count') }}</p>
             <p class="mt-2 text-2xl font-semibold text-primary-900">{{ number_format($stats['total'] ?? 0) }}</p>
@@ -22,57 +22,124 @@
             <p class="text-xs font-semibold uppercase tracking-wide text-amber-600">{{ __('cms.refunds.summary_total_amount') }}</p>
             <p class="mt-2 text-2xl font-semibold text-amber-900">{{ number_format($stats['refunded_amount'] ?? 0, 2) }}</p>
         </div>
+        <div class="rounded-2xl border border-indigo-100 bg-indigo-50 px-6 py-5">
+            <p class="text-xs font-semibold uppercase tracking-wide text-indigo-600">{{ __('cms.refunds.summary_pending_count') }}</p>
+            <p class="mt-2 text-2xl font-semibold text-indigo-900">{{ number_format($stats['pending'] ?? 0) }}</p>
+        </div>
+        <div class="rounded-2xl border border-slate-200 bg-white px-6 py-5 shadow-sm">
+            <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">{{ __('cms.refunds.summary_average_amount') }}</p>
+            <p class="mt-2 text-2xl font-semibold text-slate-900">{{ number_format($stats['average_amount'] ?? 0, 2) }}</p>
+        </div>
     </div>
 
-    <div class="bg-white border border-gray-200 shadow-sm rounded-2xl">
-        <div class="px-6 py-5 border-b border-gray-200">
-            <h2 class="text-lg font-semibold text-gray-900">{{ __('cms.refunds.filters_title') }}</h2>
+    <div class="grid gap-6 xl:grid-cols-[2fr_1fr]">
+        <div class="bg-white border border-gray-200 shadow-sm rounded-2xl">
+            <div class="px-6 py-5 border-b border-gray-200">
+                <h2 class="text-lg font-semibold text-gray-900">{{ __('cms.refunds.filters_title') }}</h2>
+            </div>
+
+            <div class="px-6 py-6">
+                <form id="refundFilters" class="grid gap-4 lg:grid-cols-6">
+                    <div class="lg:col-span-2">
+                        <label class="form-label" for="refundStatusFilter">{{ __('cms.refunds.status_filter_label') }}</label>
+                        <select
+                            id="refundStatusFilter"
+                            name="status[]"
+                            class="form-select h-36"
+                            multiple
+                            aria-describedby="refundStatusHelp"
+                        >
+                            @foreach ($statusOptions as $value => $label)
+                                <option value="{{ $value }}" @selected(in_array($value, $filters['status'] ?? []))>
+                                    {{ $label }}
+                                </option>
+                            @endforeach
+                        </select>
+                        <p id="refundStatusHelp" class="mt-2 text-xs text-gray-500">{{ __('cms.refunds.status_filter_help') }}</p>
+                    </div>
+                    <div>
+                        <label class="form-label" for="refundDateFrom">{{ __('cms.refunds.date_from_label') }}</label>
+                        <input
+                            id="refundDateFrom"
+                            type="date"
+                            name="date_from"
+                            class="form-control"
+                            value="{{ $filters['date_from'] ?? '' }}"
+                        >
+                    </div>
+                    <div>
+                        <label class="form-label" for="refundDateTo">{{ __('cms.refunds.date_to_label') }}</label>
+                        <input
+                            id="refundDateTo"
+                            type="date"
+                            name="date_to"
+                            class="form-control"
+                            value="{{ $filters['date_to'] ?? '' }}"
+                        >
+                    </div>
+                    <div>
+                        <label class="form-label" for="refundShopFilter">{{ __('cms.refunds.shop_filter_label') }}</label>
+                        <select id="refundShopFilter" name="shop_id" class="form-select">
+                            <option value="">{{ __('cms.refunds.shop_filter_placeholder') }}</option>
+                            @foreach ($shopOptions as $value => $label)
+                                <option value="{{ $value }}" @selected((string) $value === (string) ($filters['shop_id'] ?? ''))>
+                                    {{ $label }}
+                                </option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div>
+                        <label class="form-label" for="refundGatewayFilter">{{ __('cms.refunds.gateway_filter_label') }}</label>
+                        <select id="refundGatewayFilter" name="gateway_id" class="form-select">
+                            <option value="">{{ __('cms.refunds.gateway_filter_placeholder') }}</option>
+                            @foreach ($gatewayOptions as $value => $label)
+                                <option value="{{ $value }}" @selected((string) $value === (string) ($filters['gateway_id'] ?? ''))>
+                                    {{ $label }}
+                                </option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="lg:col-span-3">
+                        <label class="form-label" for="refundSearch">{{ __('cms.refunds.search_filter_label') }}</label>
+                        <input
+                            id="refundSearch"
+                            type="search"
+                            name="search_term"
+                            class="form-control"
+                            value="{{ $filters['search'] ?? '' }}"
+                            placeholder="{{ __('cms.refunds.search_filter_placeholder') }}"
+                        >
+                    </div>
+                    <div class="lg:col-span-6 flex flex-wrap gap-3 pt-2">
+                        <button type="submit" class="btn btn-primary">{{ __('cms.refunds.apply_filters') }}</button>
+                        <button type="button" class="btn btn-outline" id="resetRefundFilters">{{ __('cms.refunds.reset_filters') }}</button>
+                    </div>
+                </form>
+            </div>
         </div>
 
-        <div class="px-6 py-6">
-            <form id="refundFilters" class="grid gap-4 md:grid-cols-4">
-                <div class="md:col-span-2">
-                    <label class="form-label" for="refundStatusFilter">{{ __('cms.refunds.status_filter_label') }}</label>
-                    <select
-                        id="refundStatusFilter"
-                        name="status[]"
-                        class="form-select h-36"
-                        multiple
-                        aria-describedby="refundStatusHelp"
-                    >
-                        @foreach ($statusOptions as $value => $label)
-                            <option value="{{ $value }}" @selected(in_array($value, $filters['status'] ?? []))>
-                                {{ $label }}
-                            </option>
-                        @endforeach
-                    </select>
-                    <p id="refundStatusHelp" class="mt-2 text-xs text-gray-500">{{ __('cms.refunds.status_filter_help') }}</p>
+        <div class="bg-white border border-gray-200 shadow-sm rounded-2xl">
+            <div class="px-6 py-5 border-b border-gray-200">
+                <h2 class="text-lg font-semibold text-gray-900">{{ __('cms.refunds.shop_breakdown_title') }}</h2>
+                <p class="mt-1 text-sm text-gray-500">{{ __('cms.refunds.shop_breakdown_help') }}</p>
+            </div>
+            <div class="px-6 py-6">
+                <div class="space-y-4">
+                    @forelse ($shopBreakdown as $shop)
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <p class="text-sm font-semibold text-gray-900">{{ $shop->shop_name }}</p>
+                                <p class="text-xs text-gray-500">
+                                    {{ trans_choice('cms.refunds.shop_breakdown_count', $shop->refund_count ?? 0, ['count' => $shop->refund_count ?? 0]) }}
+                                </p>
+                            </div>
+                            <span class="text-sm font-semibold text-primary-600">{{ number_format((float) ($shop->total_amount ?? 0), 2) }}</span>
+                        </div>
+                    @empty
+                        <p class="text-sm text-gray-500">{{ __('cms.refunds.shop_breakdown_empty') }}</p>
+                    @endforelse
                 </div>
-                <div>
-                    <label class="form-label" for="refundDateFrom">{{ __('cms.refunds.date_from_label') }}</label>
-                    <input
-                        id="refundDateFrom"
-                        type="date"
-                        name="date_from"
-                        class="form-control"
-                        value="{{ $filters['date_from'] ?? '' }}"
-                    >
-                </div>
-                <div>
-                    <label class="form-label" for="refundDateTo">{{ __('cms.refunds.date_to_label') }}</label>
-                    <input
-                        id="refundDateTo"
-                        type="date"
-                        name="date_to"
-                        class="form-control"
-                        value="{{ $filters['date_to'] ?? '' }}"
-                    >
-                </div>
-                <div class="md:col-span-4 flex flex-wrap gap-3 pt-2">
-                    <button type="submit" class="btn btn-primary">{{ __('cms.refunds.apply_filters') }}</button>
-                    <button type="button" class="btn btn-outline" id="resetRefundFilters">{{ __('cms.refunds.reset_filters') }}</button>
-                </div>
-            </form>
+            </div>
         </div>
     </div>
 
@@ -87,7 +154,10 @@
                     <thead class="table-header">
                         <tr>
                             <th scope="col" class="table-header-cell">{{ __('cms.refunds.id') }}</th>
+                            <th scope="col" class="table-header-cell">{{ __('cms.refunds.reference') }}</th>
                             <th scope="col" class="table-header-cell">{{ __('cms.refunds.payment') }}</th>
+                            <th scope="col" class="table-header-cell">{{ __('cms.refunds.shop_column') }}</th>
+                            <th scope="col" class="table-header-cell">{{ __('cms.refunds.customer_column') }}</th>
                             <th scope="col" class="table-header-cell">{{ __('cms.refunds.amount') }}</th>
                             <th scope="col" class="table-header-cell">{{ __('cms.refunds.status') }}</th>
                             <th scope="col" class="table-header-cell">{{ __('cms.refunds.reason') }}</th>
@@ -145,6 +215,9 @@ document.addEventListener('DOMContentLoaded', () => {
     const filterForm = document.getElementById('refundFilters');
     const resetButton = document.getElementById('resetRefundFilters');
     const statusSelect = document.getElementById('refundStatusFilter');
+    const shopSelect = document.getElementById('refundShopFilter');
+    const gatewaySelect = document.getElementById('refundGatewayFilter');
+    const searchInput = document.getElementById('refundSearch');
 
     const dataTable = tableElement.DataTable({
         processing: true,
@@ -173,12 +246,30 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (dateTo) {
                     params.date_to = dateTo;
                 }
+
+                const shopId = formData.get('shop_id');
+                if (shopId) {
+                    params.shop_id = shopId;
+                }
+
+                const gatewayId = formData.get('gateway_id');
+                if (gatewayId) {
+                    params.gateway_id = gatewayId;
+                }
+
+                const searchTerm = formData.get('search_term');
+                if (searchTerm) {
+                    params.search_term = searchTerm;
+                }
             },
         },
         language: @json($datatableLang),
         columns: [
             { data: 'id', name: 'id' },
+            { data: 'reference', name: 'refund_id', orderable: false, searchable: false },
             { data: 'payment', name: 'payment_id' },
+            { data: 'shop', name: 'shop_name', orderable: false, searchable: false },
+            { data: 'customer', name: 'customer_name', orderable: false, searchable: false },
             { data: 'amount', name: 'amount' },
             { data: 'status', name: 'status' },
             { data: 'reason', name: 'reason' },
@@ -214,6 +305,18 @@ document.addEventListener('DOMContentLoaded', () => {
             Array.from(statusSelect.options).forEach((option) => {
                 option.selected = false;
             });
+        }
+
+        if (shopSelect) {
+            shopSelect.value = '';
+        }
+
+        if (gatewaySelect) {
+            gatewaySelect.value = '';
+        }
+
+        if (searchInput) {
+            searchInput.value = '';
         }
 
         dataTable.ajax.reload();

--- a/resources/views/admin/refunds/show.blade.php
+++ b/resources/views/admin/refunds/show.blade.php
@@ -2,24 +2,26 @@
 
 @section('content')
     @php
-        $status = strtolower($refund->status ?? 'pending');
-        $statusStyles = [
-            'completed' => 'bg-emerald-50 text-emerald-700 ring-emerald-500/20',
-            'pending' => 'bg-amber-50 text-amber-700 ring-amber-500/20',
-            'failed' => 'bg-rose-50 text-rose-700 ring-rose-500/20',
-        ];
-
-        $statusClass = $statusStyles[$status] ?? 'bg-gray-100 text-gray-700 ring-gray-500/10';
+        $statusLabel = \App\Models\Refund::labelForStatus($refund->status);
+        $statusClass = \App\Models\Refund::badgeClassForStatus($refund->status);
         $payment = $refund->payment;
-        $paymentStatus = $payment?->status ?? __('cms.refunds.not_available');
-        $paymentAmount = $payment?->amount;
-        $paymentGateway = $payment?->gateway?->name;
+        $order = $payment?->order;
+        $customer = $order?->customer;
+        $shopNames = $order
+            ? $order->details->map(fn ($detail) => $detail->product?->shop?->name)->filter()->unique()->values()
+            : collect();
+        $items = $order?->details ?? collect();
         $createdAt = optional($refund->created_at)->format('M d, Y h:i A');
         $updatedAt = optional($refund->updated_at)->format('M d, Y h:i A');
+        $timeline = [
+            ['label' => __('cms.refunds.timeline_created'), 'value' => $createdAt ?? __('cms.refunds.not_available')],
+            ['label' => __('cms.refunds.timeline_updated'), 'value' => $updatedAt ?? __('cms.refunds.not_available')],
+            ['label' => __('cms.refunds.timeline_status'), 'value' => $statusLabel],
+        ];
     @endphp
 
-    <div class="max-w-4xl mx-auto mt-4 space-y-6">
-        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <div class="max-w-5xl mx-auto mt-4 space-y-6">
+        <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
             <div>
                 <p class="text-sm font-medium text-primary-600 uppercase tracking-wide">{{ __('cms.refunds.title') }}</p>
                 <h1 class="text-3xl font-semibold text-gray-900">{{ __('cms.refunds.details_title') }}</h1>
@@ -27,82 +29,178 @@
             </div>
             <span class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-sm font-medium ring-1 {{ $statusClass }}">
                 <span class="h-2 w-2 rounded-full bg-current"></span>
-                {{ ucfirst($refund->status) }}
+                {{ $statusLabel }}
             </span>
         </div>
 
-        <div class="bg-white border border-gray-200 rounded-2xl shadow-sm">
-            <div class="px-6 py-5 border-b border-gray-200">
-                <h2 class="text-lg font-semibold text-gray-900">{{ __('cms.refunds.details_title') }}</h2>
-            </div>
-
-            <div class="px-6 py-6">
-                <dl class="grid grid-cols-1 gap-y-6 sm:grid-cols-2 sm:gap-x-6">
-                    <div>
-                        <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.id') }}</dt>
-                        <dd class="mt-1 text-base font-semibold text-gray-900">#{{ $refund->id }}</dd>
-                    </div>
-
-                    <div>
-                        <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.amount') }}</dt>
-                        <dd class="mt-1 text-base text-gray-900">{{ number_format((float) $refund->amount, 2) }}</dd>
-                    </div>
-
-                    <div class="sm:col-span-2">
-                        <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.payment') }}</dt>
-                        <dd class="mt-1 text-base text-gray-900">
-                            @if ($payment)
-                                <div class="flex flex-col gap-1">
-                                    <span class="font-semibold text-gray-900">{{ __('cms.refunds.payment') }} #{{ $payment->id }}</span>
-                                    <span class="text-sm text-gray-600">
-                                        {{ __('cms.payments.amount') }}: {{ number_format((float) $paymentAmount, 2) }}
-                                    </span>
-                                    <span class="text-sm text-gray-600">
-                                        {{ __('cms.payments.status') }}: {{ ucfirst($paymentStatus) }}
-                                    </span>
-                                    @if ($paymentGateway)
-                                        <span class="text-sm text-gray-600">
-                                            {{ __('cms.payments.gateway') }}: {{ $paymentGateway }}
-                                        </span>
-                                    @endif
-                                </div>
-                            @else
-                                <span class="text-sm text-gray-500">{{ __('cms.refunds.not_available') }}</span>
-                            @endif
-                        </dd>
-                    </div>
-
-                    <div class="sm:col-span-2">
-                        <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.reason') }}</dt>
-                        <dd class="mt-1 text-base text-gray-900 whitespace-pre-wrap">
-                            {{ $refund->reason ? $refund->reason : __('cms.refunds.not_available') }}
-                        </dd>
-                    </div>
-
-                    <div>
-                        <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.created_at') }}</dt>
-                        <dd class="mt-1 text-base text-gray-900">
-                            {{ $createdAt ?? __('cms.refunds.not_available') }}
-                        </dd>
-                    </div>
-
-                    <div>
-                        <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.updated_at') }}</dt>
-                        <dd class="mt-1 text-base text-gray-900">
-                            {{ $updatedAt ?? __('cms.refunds.not_available') }}
-                        </dd>
-                    </div>
-                </dl>
-            </div>
-
-            <div class="flex flex-col gap-3 border-t border-gray-200 bg-gray-50 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
-                <p class="text-sm text-gray-500">{{ __('cms.refunds.manage') }}</p>
-                <div class="flex items-center gap-3">
-                    <button type="button" class="btn btn-outline" data-url="{{ route('admin.refunds.index') }}">
+        <div class="grid gap-6 lg:grid-cols-3">
+            <div class="lg:col-span-2 bg-white border border-gray-200 rounded-2xl shadow-sm">
+                <div class="px-6 py-5 border-b border-gray-200 flex items-center justify-between">
+                    <h2 class="text-lg font-semibold text-gray-900">{{ __('cms.refunds.details_title') }}</h2>
+                    <button type="button" class="btn btn-outline btn-sm" data-url="{{ route('admin.refunds.index') }}">
                         {{ __('cms.refunds.back') }}
                     </button>
                 </div>
+
+                <div class="px-6 py-6 space-y-6">
+                    <dl class="grid gap-6 sm:grid-cols-2">
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.id') }}</dt>
+                            <dd class="mt-1 text-base font-semibold text-gray-900">#{{ $refund->id }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.reference') }}</dt>
+                            <dd class="mt-1 text-base text-gray-900">{{ $refund->refund_id ?? __('cms.refunds.not_available') }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.amount') }}</dt>
+                            <dd class="mt-1 text-base text-gray-900">
+                                {{ number_format((float) $refund->amount, 2) }} {{ strtoupper($refund->currency ?? '') }}
+                            </dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.status') }}</dt>
+                            <dd class="mt-1">
+                                <span class="inline-flex items-center gap-2 rounded-full px-2.5 py-1 text-xs font-medium ring-1 {{ $statusClass }}">
+                                    <span class="h-1.5 w-1.5 rounded-full bg-current"></span>
+                                    {{ $statusLabel }}
+                                </span>
+                            </dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.created_at') }}</dt>
+                            <dd class="mt-1 text-base text-gray-900">{{ $createdAt ?? __('cms.refunds.not_available') }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">{{ __('cms.refunds.updated_at') }}</dt>
+                            <dd class="mt-1 text-base text-gray-900">{{ $updatedAt ?? __('cms.refunds.not_available') }}</dd>
+                        </div>
+                    </dl>
+
+                    <div class="grid gap-6 md:grid-cols-2">
+                        <div>
+                            <h3 class="text-sm font-semibold text-gray-900">{{ __('cms.refunds.payment_summary_title') }}</h3>
+                            <dl class="mt-3 space-y-2">
+                                <div>
+                                    <dt class="text-xs uppercase tracking-wide text-gray-500">{{ __('cms.refunds.payment') }}</dt>
+                                    <dd class="text-sm text-gray-900">
+                                        @if ($payment)
+                                            {{ __('cms.refunds.payment') }} #{{ $payment->id }} · {{ number_format((float) $payment->amount, 2) }} {{ strtoupper($payment->currency ?? '') }}
+                                        @else
+                                            {{ __('cms.refunds.not_available') }}
+                                        @endif
+                                    </dd>
+                                </div>
+                                <div>
+                                    <dt class="text-xs uppercase tracking-wide text-gray-500">{{ __('cms.refunds.gateway_summary_title') }}</dt>
+                                    <dd class="text-sm text-gray-900">{{ $payment?->gateway?->name ?? __('cms.refunds.not_available') }}</dd>
+                                </div>
+                                <div>
+                                    <dt class="text-xs uppercase tracking-wide text-gray-500">{{ __('cms.refunds.order_number') }}</dt>
+                                    <dd class="text-sm text-gray-900">
+                                        @if ($order)
+                                            #{{ $order->id }}
+                                        @else
+                                            {{ __('cms.refunds.not_available') }}
+                                        @endif
+                                    </dd>
+                                </div>
+                                <div>
+                                    <dt class="text-xs uppercase tracking-wide text-gray-500">{{ __('cms.refunds.shop_column') }}</dt>
+                                    <dd class="text-sm text-gray-900">
+                                        @if ($shopNames->isNotEmpty())
+                                            {{ $shopNames->join(', ') }}
+                                        @else
+                                            {{ __('cms.refunds.not_available') }}
+                                        @endif
+                                    </dd>
+                                </div>
+                            </dl>
+
+                            @if ($order)
+                                <a href="{{ route('admin.orders.show', $order) }}" class="mt-4 inline-flex items-center text-sm font-semibold text-primary-600 hover:text-primary-700">
+                                    {{ __('cms.refunds.view_order') }}
+                                </a>
+                            @endif
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-semibold text-gray-900">{{ __('cms.refunds.customer_summary_title') }}</h3>
+                            <dl class="mt-3 space-y-2">
+                                <div>
+                                    <dt class="text-xs uppercase tracking-wide text-gray-500">{{ __('cms.refunds.customer_column') }}</dt>
+                                    <dd class="text-sm text-gray-900">
+                                        @if ($customer)
+                                            {{ $customer->name }} • {{ $customer->email }}
+                                        @elseif ($order?->guest_email)
+                                            {{ $order->guest_email }}
+                                        @else
+                                            {{ __('cms.refunds.not_available') }}
+                                        @endif
+                                    </dd>
+                                </div>
+                                <div>
+                                    <dt class="text-xs uppercase tracking-wide text-gray-500">{{ __('cms.refunds.payment_status_label') }}</dt>
+                                    <dd class="text-sm text-gray-900">
+                                        {{ $payment?->status ? ucfirst($payment->status) : __('cms.refunds.not_available') }}
+                                    </dd>
+                                </div>
+                            </dl>
+                        </div>
+                    </div>
+
+                    <div>
+                        <h3 class="text-sm font-semibold text-gray-900">{{ __('cms.refunds.reason') }}</h3>
+                        <p class="mt-2 text-sm text-gray-700 whitespace-pre-wrap">
+                            {{ $refund->reason ? $refund->reason : __('cms.refunds.not_available') }}
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="bg-white border border-gray-200 rounded-2xl shadow-sm">
+                <div class="px-6 py-5 border-b border-gray-200">
+                    <h2 class="text-lg font-semibold text-gray-900">{{ __('cms.refunds.timeline_title') }}</h2>
+                </div>
+                <div class="px-6 py-6">
+                    <ol class="space-y-4">
+                        @foreach ($timeline as $event)
+                            <li class="flex items-start gap-3">
+                                <span class="mt-1 h-2 w-2 rounded-full bg-primary-500"></span>
+                                <div>
+                                    <p class="text-xs uppercase tracking-wide text-gray-500">{{ $event['label'] }}</p>
+                                    <p class="text-sm font-medium text-gray-900">{{ $event['value'] }}</p>
+                                </div>
+                            </li>
+                        @endforeach
+                    </ol>
+                </div>
             </div>
         </div>
+
+        @if ($items->isNotEmpty())
+            <div class="bg-white border border-gray-200 rounded-2xl shadow-sm">
+                <div class="px-6 py-5 border-b border-gray-200 flex items-center justify-between">
+                    <h2 class="text-lg font-semibold text-gray-900">{{ __('cms.refunds.items_summary_title') }}</h2>
+                    @if ($order)
+                        <span class="text-sm text-gray-500">{{ __('cms.refunds.order_number') }} #{{ $order->id }}</span>
+                    @endif
+                </div>
+                <div class="px-6 py-6 space-y-4">
+                    @foreach ($items as $item)
+                        <div class="flex flex-col gap-1 border-b border-gray-100 pb-4 last:border-b-0 last:pb-0">
+                            <span class="text-sm font-semibold text-gray-900">
+                                {{ $item->product?->translation?->name ?? $item->product?->slug ?? __('cms.refunds.not_available') }}
+                            </span>
+                            <span class="text-xs text-gray-500">
+                                {{ __('cms.refunds.item_line', [
+                                    'quantity' => $item->quantity,
+                                    'price' => number_format((float) $item->price, 2),
+                                ]) }}
+                            </span>
+                        </div>
+                    @endforeach
+                </div>
+            </div>
+        @endif
     </div>
 @endsection

--- a/tests/Feature/AdminRefundManagementTest.php
+++ b/tests/Feature/AdminRefundManagementTest.php
@@ -2,7 +2,13 @@
 
 namespace Tests\Feature;
 
+use App\Models\Order;
+use App\Models\OrderDetail;
+use App\Models\Payment;
+use App\Models\PaymentGateway;
+use App\Models\Product;
 use App\Models\Refund;
+use App\Models\Shop;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -94,5 +100,129 @@ class AdminRefundManagementTest extends TestCase
         $ids = array_map(static fn ($row) => (int) $row['id'], $data);
 
         $this->assertContains($recentRefund->id, $ids);
+    }
+
+    public function test_admin_can_filter_refunds_by_shop(): void
+    {
+        $gateway = PaymentGateway::factory()->create(['code' => 'stripe']);
+        $shopA = Shop::factory()->create(['name' => 'Alpha Collective']);
+        $shopB = Shop::factory()->create(['name' => 'Beta Collective']);
+
+        $refundA = $this->createRefundForShop($shopA, $gateway, [
+            'refund_id' => 'REF-SHOP-A',
+            'status' => Refund::STATUS_COMPLETED,
+        ]);
+        $this->createRefundForShop($shopB, $gateway, [
+            'refund_id' => 'REF-SHOP-B',
+            'status' => Refund::STATUS_PENDING,
+        ]);
+
+        $response = $this->getJson(
+            route('admin.refunds.getData', [
+                'shop_id' => $shopA->id,
+            ]),
+            ['X-Requested-With' => 'XMLHttpRequest']
+        );
+
+        $response->assertOk();
+
+        $data = $response->json('data', []);
+
+        $this->assertCount(1, $data);
+        $this->assertSame('REF-SHOP-A', $data[0]['reference']);
+        $this->assertSame($shopA->name, $data[0]['shop']);
+    }
+
+    public function test_admin_can_filter_refunds_by_gateway(): void
+    {
+        $gatewayA = PaymentGateway::factory()->create(['code' => 'stripe']);
+        $gatewayB = PaymentGateway::factory()->create(['code' => 'paypal']);
+        $shop = Shop::factory()->create();
+
+        $this->createRefundForShop($shop, $gatewayA, [
+            'refund_id' => 'GATEWAY-A',
+            'status' => Refund::STATUS_COMPLETED,
+        ]);
+        $this->createRefundForShop($shop, $gatewayB, [
+            'refund_id' => 'GATEWAY-B',
+            'status' => Refund::STATUS_COMPLETED,
+        ]);
+
+        $response = $this->getJson(
+            route('admin.refunds.getData', [
+                'gateway_id' => $gatewayA->id,
+            ]),
+            ['X-Requested-With' => 'XMLHttpRequest']
+        );
+
+        $response->assertOk();
+
+        $data = $response->json('data', []);
+
+        $this->assertCount(1, $data);
+        $this->assertSame('GATEWAY-A', $data[0]['reference']);
+    }
+
+    public function test_admin_can_search_refunds_by_reference(): void
+    {
+        $gateway = PaymentGateway::factory()->create(['code' => 'stripe']);
+        $shop = Shop::factory()->create();
+
+        $targetRefund = $this->createRefundForShop($shop, $gateway, [
+            'refund_id' => 'SEARCH-123',
+            'reason' => 'Searchable refund entry',
+        ]);
+        $this->createRefundForShop($shop, $gateway, [
+            'refund_id' => 'OTHER-456',
+        ]);
+
+        $response = $this->getJson(
+            route('admin.refunds.getData', [
+                'search_term' => 'SEARCH-123',
+            ]),
+            ['X-Requested-With' => 'XMLHttpRequest']
+        );
+
+        $response->assertOk();
+
+        $data = $response->json('data', []);
+
+        $this->assertCount(1, $data);
+        $this->assertSame($targetRefund->id, (int) $data[0]['id']);
+    }
+
+    private function createRefundForShop(Shop $shop, PaymentGateway $gateway, array $attributes = []): Refund
+    {
+        $product = Product::factory()->create([
+            'shop_id' => $shop->id,
+            'vendor_id' => $shop->vendor_id,
+            'seller_id' => $shop->vendor_id,
+        ]);
+
+        $order = Order::factory()->create([
+            'status' => 'completed',
+        ]);
+
+        OrderDetail::factory()->create([
+            'order_id' => $order->id,
+            'product_id' => $product->id,
+            'quantity' => 1,
+            'price' => 75.00,
+        ]);
+
+        $payment = Payment::factory()->create([
+            'order_id' => $order->id,
+            'gateway_id' => $gateway->id,
+            'status' => 'completed',
+            'amount' => $attributes['amount'] ?? 75.00,
+            'currency' => $attributes['currency'] ?? 'USD',
+        ]);
+
+        return Refund::factory()->create(array_merge([
+            'payment_id' => $payment->id,
+            'amount' => 35.00,
+            'currency' => 'USD',
+            'status' => Refund::STATUS_COMPLETED,
+        ], $attributes));
     }
 }


### PR DESCRIPTION
## Summary
- add advanced filtering, statistics, and shop-level insights to the admin refunds dashboard
- enrich the refund detail view with payment, order, and customer context plus a status timeline
- seed showcase shop data and expanded refund fixtures to support the new experience and extend automated coverage

## Testing
- not run (composer install blocked by network restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68df95a04074832992f5e58d1aa784b6