### PR TITLE
Refactor product variant picker into reusable component

### DIFF
--- a/resources/views/themes/xylo/components/product-variant-picker.blade.php
+++ b/resources/views/themes/xylo/components/product-variant-picker.blade.php
@@ -1,0 +1,61 @@
+@props([
+    'product',
+    'variantMap' => [],
+    'inStock' => false,
+])
+
+<div
+    id="product-variant-picker"
+    data-product-id="{{ $product->id }}"
+    data-product-type="{{ $product->product_type }}"
+    data-cart-url="{{ route('cart.add') }}"
+    data-csrf-token="{{ csrf_token() }}"
+    data-variant-map='@json($variantMap)'
+    data-in-stock="{{ $inStock ? 'true' : 'false' }}"
+>
+    <div id="product-attributes" class="product-options">
+        @php
+            $groupedAttributes = $product->attributeValues->groupBy(fn($item) => $item->attribute->id);
+        @endphp
+
+        @foreach ($groupedAttributes as $attributeId => $values)
+            <div class="attribute-options mt-3">
+                <h3>{{ $values->first()->attribute->name }}</h3>
+                <div class="{{ strtolower($values->first()->attribute->name) }}-wrapper">
+                    @foreach ($values as $index => $value)
+                        @php
+                            $inputId = strtolower($values->first()->attribute->name) . '-' . $index;
+                        @endphp
+                        <input
+                            type="radio"
+                            name="attribute_{{ $attributeId }}"
+                            id="{{ $inputId }}"
+                            value="{{ $value->id }}"
+                            {{ $index === 0 ? 'checked' : '' }}
+                        >
+                        <label
+                            for="{{ $inputId }}"
+                            class="{{ strtolower($values->first()->attribute->name) === 'color' ? 'color-circle ' . strtolower($value->translated_value) : 'size-box' }}"
+                        >
+                            @if (strtolower($values->first()->attribute->name) === 'size')
+                                {{ $value->translated_value }}
+                            @endif
+                        </label>
+                    @endforeach
+                </div>
+            </div>
+        @endforeach
+    </div>
+
+    <div class="cart-actions mt-3 d-flex">
+        <div class="quantity me-4">
+            <button type="button" class="quantity-btn" data-change="-1">-</button>
+            <input type="text" id="qty" value="1">
+            <button type="button" class="quantity-btn" data-change="1">+</button>
+        </div>
+        <button type="button" class="add-to-cart read-more">
+            {{ __('store.product_detail.add_to_cart') }}
+        </button>
+    </div>
+</div>
+

--- a/resources/views/themes/xylo/js/product-variant-picker.js
+++ b/resources/views/themes/xylo/js/product-variant-picker.js
@@ -1,0 +1,177 @@
+document.addEventListener('DOMContentLoaded', () => {
+    const picker = document.getElementById('product-variant-picker');
+
+    if (!picker) {
+        return;
+    }
+
+    const productId = parseInt(picker.dataset.productId, 10);
+    const productType = picker.dataset.productType;
+    const cartUrl = picker.dataset.cartUrl;
+    const csrfToken = picker.dataset.csrfToken;
+    const variantPrice = document.getElementById('variant-price');
+    const productStock = document.getElementById('product-stock');
+    const currencySymbol = document.getElementById('currency-symbol');
+
+    let variantMap = [];
+
+    try {
+        variantMap = JSON.parse(picker.dataset.variantMap || '[]');
+    } catch (error) {
+        console.error('Unable to parse variant map data.', error);
+    }
+
+    const qtyInput = picker.querySelector('#qty');
+    const quantityButtons = picker.querySelectorAll('.quantity-btn');
+    const addToCartButton = picker.querySelector('.add-to-cart');
+
+    function getSelectedAttributeValueIds() {
+        return Array.from(picker.querySelectorAll('#product-attributes input[type="radio"]:checked'))
+            .map((input) => parseInt(input.value, 10))
+            .filter((value) => !Number.isNaN(value))
+            .sort((a, b) => a - b);
+    }
+
+    function findMatchingVariantId(selectedAttrIds) {
+        for (const variant of variantMap) {
+            const variantAttrIds = variant.attributes.slice().sort((a, b) => a - b);
+            if (JSON.stringify(variantAttrIds) === JSON.stringify(selectedAttrIds)) {
+                return variant.id;
+            }
+        }
+        return null;
+    }
+
+    function updateVariantPricing(variantId) {
+        if (!variantId) {
+            return;
+        }
+
+        const params = new URLSearchParams({
+            variant_id: variantId,
+            product_id: productId,
+        });
+
+        fetch(`/get-variant-price?${params.toString()}`, {
+            headers: {
+                Accept: 'application/json',
+            },
+        })
+            .then((response) => response.json())
+            .then((data) => {
+                if (!data.success) {
+                    console.log('Unable to fetch variant price.');
+                    return;
+                }
+
+                if (variantPrice) {
+                    variantPrice.textContent = data.price;
+                }
+
+                if (productStock) {
+                    productStock.textContent = data.stock;
+                    if (data.is_out_of_stock) {
+                        productStock.classList.add('text-danger');
+                    } else {
+                        productStock.classList.remove('text-danger');
+                    }
+                }
+
+                if (currencySymbol) {
+                    currencySymbol.textContent = data.currency_symbol;
+                }
+            })
+            .catch(() => {
+                alert('Something went wrong. Please try again.');
+            });
+    }
+
+    function updateCartCount(cart) {
+        const totalCount = Object.values(cart).reduce((sum, item) => sum + item.quantity, 0);
+        const cartCount = document.getElementById('cart-count');
+
+        if (cartCount) {
+            cartCount.textContent = totalCount;
+        }
+    }
+
+    function handleAddToCart() {
+        const quantity = parseInt(qtyInput?.value, 10) || 1;
+        const selectedAttributes = getSelectedAttributeValueIds();
+
+        fetch(cartUrl, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-CSRF-TOKEN': csrfToken,
+                Accept: 'application/json',
+            },
+            body: JSON.stringify({
+                product_id: productId,
+                quantity,
+                attribute_value_ids: selectedAttributes,
+                product_type: productType,
+            }),
+        })
+            .then((response) => response.json())
+            .then((data) => {
+                if (typeof toastr !== 'undefined') {
+                    if (data.success === false && data.message) {
+                        toastr.error(data.message);
+                    } else if (data.message) {
+                        toastr.success(data.message);
+                    }
+                }
+
+                if (data.cart) {
+                    updateCartCount(data.cart);
+                }
+            })
+            .catch((error) => console.error('Error:', error));
+    }
+
+    function changeQty(amount) {
+        const currentQty = parseInt(qtyInput?.value, 10) || 1;
+        let newQty = currentQty + amount;
+
+        if (newQty < 1) {
+            newQty = 1;
+        }
+
+        if (qtyInput) {
+            qtyInput.value = String(newQty);
+        }
+    }
+
+    function handleAttributeChange() {
+        const selectedAttrIds = getSelectedAttributeValueIds();
+        const variantId = findMatchingVariantId(selectedAttrIds);
+
+        if (!variantId) {
+            alert('Selected variant not available.');
+            return;
+        }
+
+        updateVariantPricing(variantId);
+    }
+
+    quantityButtons.forEach((button) => {
+        button.addEventListener('click', (event) => {
+            const amount = parseInt(event.currentTarget.dataset.change, 10);
+            if (!Number.isNaN(amount)) {
+                changeQty(amount);
+            }
+        });
+    });
+
+    if (addToCartButton) {
+        addToCartButton.addEventListener('click', handleAddToCart);
+    }
+
+    picker.querySelectorAll('#product-attributes input[type="radio"]').forEach((input) => {
+        input.addEventListener('change', handleAttributeChange);
+    });
+
+    handleAttributeChange();
+});
+

--- a/resources/views/themes/xylo/layouts/master.blade.php
+++ b/resources/views/themes/xylo/layouts/master.blade.php
@@ -46,6 +46,9 @@
     @if (!App::environment('testing'))
         @vite(['resources/views/themes/xylo/js/main.js'])
     @endif
+    @if (!App::environment('testing'))
+        @vite(['resources/views/themes/xylo/js/product-variant-picker.js'])
+    @endif
     @yield('js')
     <script>
         $(document).ready(function() {


### PR DESCRIPTION
## Summary
- extract the product variant selection UI into a dedicated Blade component
- move variant selection, pricing, and cart handlers into a standalone JavaScript module and register it with the layout
- update the product detail view to render the component and rely on the shared script

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e01eae276483299874105c1e53ee08