### PR TITLE
Upgrade admin product variant module

### DIFF
--- a/app/Http/Controllers/Admin/ProductVariantController.php
+++ b/app/Http/Controllers/Admin/ProductVariantController.php
@@ -7,44 +7,64 @@ use App\Models\Language;
 use App\Models\Product;
 use App\Models\ProductVariant;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Illuminate\Validation\Rule;
 use Yajra\DataTables\Facades\DataTables;
 
 class ProductVariantController extends Controller
 {
     public function index()
     {
-        /* $productVariants = ProductVariant::with('product.translations', 'translations')
-         ->paginate(10);
-
-         $languages = Language::active()->get();
-
-         return view('admin.product_variants.index', compact('productVariants', 'languages')); */
-
-        $languages = Language::active()->get(); // Get active languages
+        $languages = Language::active()->orderBy('name')->get();
 
         return view('admin.product_variants.index', compact('languages'));
     }
 
     public function getData(Request $request)
     {
-        $productVariants = ProductVariant::with('product', 'translations')
-            ->select('product_variants.*'); // Use select to avoid eager loading too much data
+        $locale = app()->getLocale();
+
+        $productVariants = ProductVariant::query()
+            ->with([
+                'product.translations' => function ($query) use ($locale) {
+                    $query->where('language_code', $locale);
+                },
+                'translations' => function ($query) use ($locale) {
+                    $query->where('language_code', $locale);
+                },
+            ])
+            ->select('product_variants.*');
 
         return DataTables::of($productVariants)
-            ->addColumn('id', function ($productVariant) {
-                return $productVariant->id;  // Add the ID here
+            ->addColumn('id', fn (ProductVariant $productVariant) => $productVariant->id)
+            ->addColumn('product', function (ProductVariant $productVariant) {
+                $productTranslation = $productVariant->product?->translations->first();
+
+                return $productTranslation?->name ?? __('cms.product_variants.not_available');
             })
-            ->addColumn('product', function ($productVariant) {
-                return $productVariant->product->translations->first()->name ?? 'Unknown Product';
+            ->addColumn('variant_name', function (ProductVariant $productVariant) {
+                if (filled($productVariant->name)) {
+                    return $productVariant->name;
+                }
+
+                $translation = $productVariant->translations->first();
+
+                return $translation?->name ?? __('cms.product_variants.not_available');
             })
-            ->addColumn('variant_name', function ($productVariant) {
-                return $productVariant->translations->first()->name ?? 'N/A';
+            ->addColumn('value', function (ProductVariant $productVariant) {
+                if (filled($productVariant->value)) {
+                    return $productVariant->value;
+                }
+
+                return optional($productVariant->translations->first())->value
+                    ?? __('cms.product_variants.not_available');
             })
-            ->addColumn('action', function ($productVariant) {
+            ->addColumn('SKU', fn (ProductVariant $productVariant) => $productVariant->SKU)
+            ->addColumn('action', function (ProductVariant $productVariant) {
                 $editRoute = route('admin.product_variants.edit', $productVariant->id);
-                $editLabel = e(__('cms.products.edit_button'));
-                $deleteLabel = e(__('cms.coupons.delete_button'));
+                $editLabel = e(__('cms.product_variants.edit_button'));
+                $deleteLabel = e(__('cms.product_variants.delete_button'));
 
                 return <<<HTML
                     <div class="flex flex-col gap-2">
@@ -73,39 +93,52 @@ class ProductVariantController extends Controller
             }])
             ->get();
 
-        $languages = Language::active()->get();
+        $languages = Language::active()->orderBy('name')->get();
 
         return view('admin.product_variants.create', compact('products', 'languages'));
     }
 
     public function store(Request $request)
     {
-        $request->validate([
-            'product_id' => 'required|exists:products,id',
-            'name' => 'required|string|max:255',
-            'price' => 'required|numeric',
-            'stock' => 'required|integer',
-            'translations' => 'required|array',
-            'translations.*.name' => 'required|string|max:255',
-            'translations.*.value' => 'nullable|string|max:255',
+        $this->normalizeRequest($request);
+
+        $validated = $request->validate([
+            'product_id' => ['required', 'exists:products,id'],
+            'variant_slug' => ['nullable', 'string', 'max:255', 'unique:product_variants,variant_slug'],
+            'name' => ['required', 'string', 'max:255'],
+            'value' => ['nullable', 'string', 'max:255'],
+            'price' => ['required', 'numeric', 'min:0'],
+            'discount_price' => ['nullable', 'numeric', 'min:0'],
+            'stock' => ['required', 'integer', 'min:0'],
+            'SKU' => ['required', 'string', 'max:255', 'unique:product_variants,SKU'],
+            'barcode' => ['nullable', 'string', 'max:255'],
+            'weight' => ['nullable', 'numeric', 'min:0'],
+            'dimensions' => ['nullable', 'string', 'max:255'],
+            'translations' => ['required', 'array'],
+            'translations.*.name' => ['required', 'string', 'max:255'],
+            'translations.*.value' => ['nullable', 'string', 'max:255'],
         ]);
 
-        $translations = $request->input('translations');
-        $productVariantData = $request->except('translations');
+        $translations = $validated['translations'];
+        unset($validated['translations']);
 
-        $productVariantData['variant_slug'] = Str::slug($request->input('name'));
+        $variantData = $this->prepareVariantPayload($validated);
 
-        $productVariant = ProductVariant::create($productVariantData);
+        DB::transaction(function () use ($translations, $variantData) {
+            $variant = ProductVariant::create($variantData);
 
-        foreach ($translations as $locale => $translation) {
-            $productVariant->translations()->create([
-                'locale' => $locale,
-                'name' => $translation['name'],
-                'value' => $translation['value'] ?? null,
-            ]);
-        }
+            foreach ($translations as $languageCode => $translation) {
+                $variant->translations()->create([
+                    'language_code' => $languageCode,
+                    'name' => $translation['name'],
+                    'value' => $translation['value'] ?? null,
+                ]);
+            }
+        });
 
-        return redirect()->route('admin.product_variants.index')->with('success', 'Product Variant created successfully.');
+        return redirect()
+            ->route('admin.product_variants.index')
+            ->with('success', __('cms.product_variants.create_success'));
     }
 
     public function edit($id)
@@ -118,42 +151,71 @@ class ProductVariantController extends Controller
             }])
             ->get();
 
-        $languages = Language::active()->get();
+        $languages = Language::active()->orderBy('name')->get();
 
         return view('admin.product_variants.edit', compact('productVariant', 'products', 'languages'));
     }
 
     public function update(Request $request, $id)
     {
-        $request->validate([
-            'variant_slug' => 'required|unique:product_variants,variant_slug,'.$id,
-            'name' => 'required|string|max:255',
-            'price' => 'required|numeric',
-            'stock' => 'required|integer',
-            'translations' => 'required|array',
-            'translations.*.name' => 'required|string|max:255',
-            'translations.*.value' => 'nullable|string|max:255',
+        $this->normalizeRequest($request);
+
+        $validated = $request->validate([
+            'product_id' => ['required', 'exists:products,id'],
+            'variant_slug' => [
+                'nullable',
+                'string',
+                'max:255',
+                Rule::unique('product_variants', 'variant_slug')->ignore($id),
+            ],
+            'name' => ['required', 'string', 'max:255'],
+            'value' => ['nullable', 'string', 'max:255'],
+            'price' => ['required', 'numeric', 'min:0'],
+            'discount_price' => ['nullable', 'numeric', 'min:0'],
+            'stock' => ['required', 'integer', 'min:0'],
+            'SKU' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('product_variants', 'SKU')->ignore($id),
+            ],
+            'barcode' => ['nullable', 'string', 'max:255'],
+            'weight' => ['nullable', 'numeric', 'min:0'],
+            'dimensions' => ['nullable', 'string', 'max:255'],
+            'translations' => ['required', 'array'],
+            'translations.*.name' => ['required', 'string', 'max:255'],
+            'translations.*.value' => ['nullable', 'string', 'max:255'],
         ]);
 
-        $translations = $request->input('translations');
-        $productVariantData = $request->except('translations');
-
-        $productVariantData['variant_slug'] = Str::slug($request->input('name'));
+        $translations = $validated['translations'];
+        unset($validated['translations']);
 
         $productVariant = ProductVariant::findOrFail($id);
-        $productVariant->update($productVariantData);
+        $variantData = $this->prepareVariantPayload($validated, $productVariant->id);
 
-        foreach ($translations as $locale => $translation) {
-            $productVariant->translations()->updateOrCreate(
-                ['locale' => $locale],
-                [
-                    'name' => $translation['name'],
-                    'value' => $translation['value'] ?? null,
-                ]
-            );
-        }
+        DB::transaction(function () use ($productVariant, $translations, $variantData) {
+            $productVariant->update($variantData);
 
-        return redirect()->route('admin.product_variants.index')->with('success', 'Product Variant updated successfully.');
+            $languageCodes = array_keys($translations);
+
+            foreach ($translations as $languageCode => $translation) {
+                $productVariant->translations()->updateOrCreate(
+                    ['language_code' => $languageCode],
+                    [
+                        'name' => $translation['name'],
+                        'value' => $translation['value'] ?? null,
+                    ]
+                );
+            }
+
+            $productVariant->translations()
+                ->whereNotIn('language_code', $languageCodes)
+                ->delete();
+        });
+
+        return redirect()
+            ->route('admin.product_variants.index')
+            ->with('success', __('cms.product_variants.update_success'));
     }
 
     public function destroy($id)
@@ -165,13 +227,72 @@ class ProductVariantController extends Controller
 
             return response()->json([
                 'success' => true,
-                'message' => 'Product Variant deleted successfully.',
+                'message' => __('cms.product_variants.delete_success_message'),
             ]);
         } catch (\Exception $e) {
             return response()->json([
                 'success' => false,
-                'message' => 'An error occurred while deleting the product variant.',
+                'message' => __('cms.product_variants.delete_error_message'),
             ]);
         }
+    }
+
+    protected function prepareVariantPayload(array $data, ?int $ignoreId = null): array
+    {
+        $name = trim($data['name']);
+        $slugSource = isset($data['variant_slug']) ? trim($data['variant_slug']) : $name;
+        $data['variant_slug'] = $this->generateUniqueSlug($slugSource, $ignoreId);
+        $data['name'] = $name;
+        $value = $data['value'] ?? null;
+        $data['value'] = filled($value) ? trim((string) $value) : null;
+        $data['price'] = (float) $data['price'];
+        $data['discount_price'] = isset($data['discount_price']) ? (float) $data['discount_price'] : null;
+        $data['stock'] = (int) $data['stock'];
+        $data['weight'] = isset($data['weight']) ? (float) $data['weight'] : null;
+
+        if (isset($data['SKU'])) {
+            $data['SKU'] = trim((string) $data['SKU']);
+        }
+
+        foreach (['barcode', 'dimensions'] as $stringField) {
+            if (array_key_exists($stringField, $data)) {
+                $value = trim((string) $data[$stringField]);
+                $data[$stringField] = $value !== '' ? $value : null;
+            }
+        }
+
+        return $data;
+    }
+
+    protected function normalizeRequest(Request $request): void
+    {
+        $nullableFields = ['variant_slug', 'value', 'discount_price', 'barcode', 'weight', 'dimensions'];
+
+        foreach ($nullableFields as $field) {
+            if (! $request->filled($field)) {
+                $request->merge([$field => null]);
+            }
+        }
+    }
+
+    protected function generateUniqueSlug(string $source, ?int $ignoreId = null): string
+    {
+        $base = Str::slug($source);
+
+        if ($base === '') {
+            $base = 'variant';
+        }
+
+        $slug = $base;
+        $counter = 1;
+
+        while (ProductVariant::where('variant_slug', $slug)
+            ->when($ignoreId, fn ($query) => $query->where('id', '!=', $ignoreId))
+            ->exists()) {
+            $slug = $base . '-' . $counter;
+            $counter++;
+        }
+
+        return $slug;
     }
 }

--- a/app/Models/ProductVariant.php
+++ b/app/Models/ProductVariant.php
@@ -11,6 +11,8 @@ class ProductVariant extends Model
 
     protected $fillable = [
         'product_id',
+        'name',
+        'value',
         'variant_slug',
         'price',
         'discount_price',

--- a/app/Models/ProductVariantTranslation.php
+++ b/app/Models/ProductVariantTranslation.php
@@ -13,6 +13,7 @@ class ProductVariantTranslation extends Model
         'product_variant_id',
         'language_code',
         'name',
+        'value',
     ];
 
     // Relationship with the ProductVariant model

--- a/database/migrations/2025_04_07_000001_add_details_to_product_variants_tables.php
+++ b/database/migrations/2025_04_07_000001_add_details_to_product_variants_tables.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('product_variants', function (Blueprint $table) {
+            if (! Schema::hasColumn('product_variants', 'name')) {
+                $table->string('name')->default('')->after('product_id');
+            }
+
+            if (! Schema::hasColumn('product_variants', 'value')) {
+                $table->string('value')->nullable()->after('name');
+            }
+        });
+
+        Schema::table('product_variant_translations', function (Blueprint $table) {
+            if (! Schema::hasColumn('product_variant_translations', 'value')) {
+                $table->string('value')->nullable()->after('name');
+            }
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('product_variant_translations', function (Blueprint $table) {
+            if (Schema::hasColumn('product_variant_translations', 'value')) {
+                $table->dropColumn('value');
+            }
+        });
+
+        Schema::table('product_variants', function (Blueprint $table) {
+            if (Schema::hasColumn('product_variants', 'value')) {
+                $table->dropColumn('value');
+            }
+
+            if (Schema::hasColumn('product_variants', 'name')) {
+                $table->dropColumn('name');
+            }
+        });
+    }
+};

--- a/lang/en/cms.php
+++ b/lang/en/cms.php
@@ -227,6 +227,11 @@ return [
         'delete_confirm_accept' => 'Delete',
         'delete_success_message' => 'Product variant deleted successfully.',
         'delete_error_message' => 'Error deleting product variant.',
+        'create_success' => 'Product variant created successfully.',
+        'update_success' => 'Product variant updated successfully.',
+        'edit_button' => 'Edit',
+        'delete_button' => 'Delete',
+        'not_available' => 'N/A',
     ],
 
     'refunds' => [

--- a/resources/views/admin/product_variants/form.blade.php
+++ b/resources/views/admin/product_variants/form.blade.php
@@ -277,7 +277,7 @@
                                 $langCode = $language->code;
                                 $languageName = ucwords($language->name ?? $langCode);
                                 $existingTranslation = $isEdit && $productVariant
-                                    ? $productVariant->translations->firstWhere('locale', $langCode)
+                                    ? $productVariant->translations->firstWhere('language_code', $langCode)
                                     : null;
                                 $nameValue = old("translations.$langCode.name", $existingTranslation->name ?? '');
                                 $valueValue = old("translations.$langCode.value", $existingTranslation->value ?? '');


### PR DESCRIPTION
## Summary
- add missing database columns for product variant names and values and expose them via fillable attributes
- overhaul the admin product variant controller to normalize input, enforce validation, generate unique slugs, and manage localized translations
- update product variant views and language resources to use language_code keys and provide UI labels for new behaviors

## Testing
- php artisan test --filter=ProductVariant *(fails: vendor/autoload.php missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e04151a7988329bbb53cce8c31b88e