### PR TITLE
Fix product variant language tabs bootstrap detection

### DIFF
--- a/resources/views/admin/product_variants/form.blade.php
+++ b/resources/views/admin/product_variants/form.blade.php
@@ -345,7 +345,10 @@
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             const form = document.getElementById('productVariantForm');
-            if (!form || typeof bootstrap === 'undefined') {
+            const bootstrapNamespace =
+                window.bootstrap ?? (typeof bootstrap !== 'undefined' ? bootstrap : undefined);
+
+            if (!form || !bootstrapNamespace || !bootstrapNamespace.Tab) {
                 return;
             }
 
@@ -401,7 +404,7 @@
                     : null;
 
                 pendingFocusElement = focusTarget;
-                bootstrap.Tab.getOrCreateInstance(trigger).show();
+                bootstrapNamespace.Tab.getOrCreateInstance(trigger).show();
             };
 
             tabTriggers.forEach((trigger) => {


### PR DESCRIPTION
## Summary
- ensure the product variant create form checks for the Bootstrap namespace on window before attempting to initialise tabs

## Testing
- php artisan test *(fails: missing Composer dependencies in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e041652bb48329ace837efc237a901