### PR TITLE
Improve category creation localization tabs

### DIFF
--- a/lang/en/cms.php
+++ b/lang/en/cms.php
@@ -713,6 +713,8 @@ return [
         'status_filter_inactive' => 'Inactive',
         'translations_section_title' => 'Translations',
         'translations_section_description' => 'Provide localized names, descriptions, and media for each active language.',
+        'language_tabs_label' => 'Category translation languages',
+        'language_tab_button' => ':language translation tab',
         'back_to_index' => 'Back to categories',
         'apply_filters' => 'Apply filters',
         'reset_filters' => 'Reset',

--- a/resources/views/admin/categories/create.blade.php
+++ b/resources/views/admin/categories/create.blade.php
@@ -10,12 +10,14 @@
         </x-admin.button-link>
     </x-admin.page-header>
 
-    @include('admin.categories.partials.form', [
-        'formAction' => route('admin.categories.store'),
-        'formMethod' => 'POST',
-        'parentOptions' => $parentOptions,
-        'selectedParent' => $selectedParent ?? null,
-        'category' => null,
-        'activeLanguages' => $activeLanguages,
-    ])
+    <div class="mt-6">
+        @include('admin.categories.partials.form', [
+            'formAction' => route('admin.categories.store'),
+            'formMethod' => 'POST',
+            'parentOptions' => $parentOptions,
+            'selectedParent' => $selectedParent ?? null,
+            'category' => null,
+            'activeLanguages' => $activeLanguages,
+        ])
+    </div>
 @endsection

--- a/resources/views/admin/categories/partials/form.blade.php
+++ b/resources/views/admin/categories/partials/form.blade.php
@@ -60,6 +60,11 @@
     }
 
     $initialTab = $languageCodes->first();
+    $oldActiveTab = old('active_language');
+
+    if ($oldActiveTab && $languageCodes->contains($oldActiveTab)) {
+        $initialTab = $oldActiveTab;
+    }
 @endphp
 
 <form
@@ -83,6 +88,8 @@
     @if ($formMethod !== 'POST')
         @method($formMethod)
     @endif
+
+    <input type="hidden" name="active_language" x-model="activeTab">
 
     @if ($errors->any())
         <div class="alert alert-danger">
@@ -143,13 +150,25 @@
 
     <x-admin.card
         :title="__('cms.categories.translations_section_title')"
-        :actions="view('admin.categories.partials.language-tabs', ['languages' => $languages])"
+        :actions="view('admin.categories.partials.language-tabs', [
+            'languages' => $languages,
+            'errorLanguages' => $errorLanguages ?? collect(),
+        ])"
     >
         <p class="text-sm text-gray-500 mb-6">{{ __('cms.categories.translations_section_description') }}</p>
 
         @foreach($languages as $language)
             @php($code = $language->code)
-            <section x-show="activeTab === '{{ $code }}'" x-cloak class="space-y-6">
+            @php($tabId = \Illuminate\Support\Str::slug($code))
+            <section
+                id="category-language-panel-{{ $tabId }}"
+                x-show="activeTab === '{{ $code }}'"
+                x-cloak
+                class="space-y-6"
+                role="tabpanel"
+                aria-labelledby="category-language-tab-{{ $tabId }}"
+                x-bind:aria-hidden="activeTab !== '{{ $code }}'"
+            >
                 <div>
                     <label class="form-label" for="category-name-{{ $code }}">
                         {{ __('cms.categories.name') }} ({{ strtoupper($code) }})

--- a/resources/views/admin/categories/partials/language-tabs.blade.php
+++ b/resources/views/admin/categories/partials/language-tabs.blade.php
@@ -1,16 +1,91 @@
-<nav class="flex flex-wrap gap-2" role="tablist">
-    @foreach ($languages as $language)
-        @php($code = $language->code)
-        <button
-            type="button"
-            @click="setActiveTab('{{ $code }}')"
-            :class="activeTab === '{{ $code }}' ? 'nav-tab-active' : 'nav-tab-inactive'"
-            class="nav-tab"
-        >
-            <span class="inline-flex items-center gap-2">
-                <span class="text-xs font-semibold uppercase text-gray-500">{{ strtoupper($code) }}</span>
-                <span class="text-sm font-medium text-gray-700">{{ ucwords($language->name ?? $code) }}</span>
-            </span>
-        </button>
-    @endforeach
-</nav>
+@php
+    $languages = isset($languages) ? collect($languages) : collect();
+    $errorLanguages = collect($errorLanguages ?? [])
+        ->map(fn ($code) => (string) $code)
+        ->filter()
+        ->values()
+        ->all();
+    $initialActive = old('active_language') ?? ($languages->first()->code ?? null);
+@endphp
+
+@if ($languages->count())
+    <nav
+        class="flex flex-wrap gap-2 border-b border-gray-200 pb-2"
+        role="tablist"
+        aria-label="{{ __('cms.categories.language_tabs_label') }}"
+    >
+        @foreach ($languages as $language)
+            @php
+                $code = (string) $language->code;
+                $tabId = \Illuminate\Support\Str::slug($code);
+                $hasErrors = in_array($code, $errorLanguages, true);
+                $isInitiallyActive = $initialActive === $code;
+            @endphp
+            <button
+                type="button"
+                id="category-language-tab-{{ $tabId }}"
+                role="tab"
+                aria-controls="category-language-panel-{{ $tabId }}"
+                @class([
+                    'relative nav-tab transition-colors duration-200 focus:outline-none',
+                    'nav-tab-active' => $isInitiallyActive,
+                    'nav-tab-inactive' => ! $isInitiallyActive,
+                    '!text-danger-600' => $hasErrors && ! $isInitiallyActive,
+                    '!text-danger-700' => $hasErrors && $isInitiallyActive,
+                ])
+                :class="{
+                    'nav-tab-active': activeTab === '{{ $code }}',
+                    'nav-tab-inactive': activeTab !== '{{ $code }}',
+                    '!text-danger-600': errorTabs.includes('{{ $code }}') && activeTab !== '{{ $code }}',
+                    '!text-danger-700': errorTabs.includes('{{ $code }}') && activeTab === '{{ $code }}',
+                }"
+                aria-selected="{{ $isInitiallyActive ? 'true' : 'false' }}"
+                :aria-selected="activeTab === '{{ $code }}'"
+                @click="setActiveTab('{{ $code }}')"
+            >
+                <span class="inline-flex items-center gap-2">
+                    <span
+                        @class([
+                            'text-xs font-semibold uppercase transition-colors duration-200',
+                            'text-gray-500' => ! $hasErrors,
+                            '!text-danger-600' => $hasErrors,
+                        ])
+                        :class="{
+                            '!text-danger-600': errorTabs.includes('{{ $code }}'),
+                            'text-gray-500': ! errorTabs.includes('{{ $code }}'),
+                        }"
+                    >
+                        {{ strtoupper($code) }}
+                    </span>
+                    <span
+                        @class([
+                            'text-sm font-medium transition-colors duration-200',
+                            'text-gray-700' => ! $hasErrors,
+                            '!text-danger-600' => $hasErrors,
+                        ])
+                        :class="{
+                            '!text-danger-600': errorTabs.includes('{{ $code }}'),
+                            'text-gray-700': ! errorTabs.includes('{{ $code }}'),
+                        }"
+                    >
+                        {{ ucwords($language->name ?? $code) }}
+                    </span>
+                </span>
+
+                <span class="sr-only">
+                    {{ __('cms.categories.language_tab_button', ['language' => ucwords($language->name ?? $code)]) }}
+                </span>
+
+                <span
+                    @class([
+                        'absolute -top-1 -right-1 h-2.5 w-2.5 rounded-full bg-danger-500',
+                        'hidden' => ! $hasErrors,
+                    ])
+                    x-show="errorTabs.includes('{{ $code }}')"
+                    x-cloak
+                    aria-hidden="true"
+                ></span>
+            </button>
+        @endforeach
+    </nav>
+@endif


### PR DESCRIPTION
## Summary
- add spacing wrapper around the category create form include for consistency
- enhance the shared category form to remember the active language, expose ARIA attributes, and surface validation error tabs
- rebuild the category language tab partial with accessibility labels, visual error cues, and translation helpers
- add English translation strings for the new language tab labels

## Testing
- php artisan test *(fails: vendor/autoload.php missing in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0418cc3888329895a5f77dccf8836