### PR TITLE
Enhance admin coupons dashboard

### DIFF
--- a/app/Models/Coupon.php
+++ b/app/Models/Coupon.php
@@ -31,6 +31,21 @@ class Coupon extends Model
         return $this->expires_at ? $this->expires_at->isPast() : false;
     }
 
+    public function isExpiringSoon(int $days = 7): bool
+    {
+        if (! $this->expires_at) {
+            return false;
+        }
+
+        $now = now();
+
+        if ($this->expires_at->isPast()) {
+            return false;
+        }
+
+        return $this->expires_at->lte($now->copy()->addDays($days));
+    }
+
     public function hasReachedUsageLimit(): bool
     {
         if ($this->usage_limit === null) {

--- a/database/seeders/CouponSeeder.php
+++ b/database/seeders/CouponSeeder.php
@@ -22,6 +22,7 @@ class CouponSeeder extends Seeder
                 'type' => 'percentage',
                 'minimum_spend' => 50,
                 'usage_limit' => 500,
+                'usage_count' => 0,
                 'expires_at' => $now->copy()->addMonths(6),
             ],
             [
@@ -30,6 +31,7 @@ class CouponSeeder extends Seeder
                 'type' => 'fixed',
                 'minimum_spend' => 100,
                 'usage_limit' => 200,
+                'usage_count' => 25,
                 'expires_at' => $now->copy()->addMonths(3),
             ],
             [
@@ -38,6 +40,7 @@ class CouponSeeder extends Seeder
                 'type' => 'fixed',
                 'minimum_spend' => null,
                 'usage_limit' => null,
+                'usage_count' => 0,
                 'expires_at' => null,
             ],
             [
@@ -46,7 +49,26 @@ class CouponSeeder extends Seeder
                 'type' => 'percentage',
                 'minimum_spend' => 150,
                 'usage_limit' => 100,
+                'usage_count' => 0,
                 'expires_at' => $now->copy()->subDay(),
+            ],
+            [
+                'code' => 'LASTCALL',
+                'discount' => 20,
+                'type' => 'percentage',
+                'minimum_spend' => 80,
+                'usage_limit' => 75,
+                'usage_count' => 10,
+                'expires_at' => $now->copy()->addDays(5),
+            ],
+            [
+                'code' => 'BULK15',
+                'discount' => 15,
+                'type' => 'fixed',
+                'minimum_spend' => 250,
+                'usage_limit' => null,
+                'usage_count' => 0,
+                'expires_at' => null,
             ],
         ];
 
@@ -59,7 +81,7 @@ class CouponSeeder extends Seeder
                     'minimum_spend' => $coupon['minimum_spend'],
                     'usage_limit' => $coupon['usage_limit'],
                     'expires_at' => $coupon['expires_at'],
-                    'usage_count' => 0,
+                    'usage_count' => $coupon['usage_count'] ?? 0,
                 ]
             );
         }

--- a/lang/en/cms.php
+++ b/lang/en/cms.php
@@ -1406,18 +1406,39 @@ return [
         'status_labels' => [
             'active' => 'Active',
             'expired' => 'Expired',
+            'expiring_soon' => 'Expiring soon',
         ],
 
         'filters' => [
             'all' => 'All coupons',
             'active' => 'Active',
             'expired' => 'Expired',
+            'expiring_soon' => 'Expiring soon',
+            'search_label' => 'Search coupons',
+            'search_placeholder' => 'Search by code or ID…',
+            'apply' => 'Apply filters',
+            'reset' => 'Reset filters',
+            'active_notice' => 'Filters are active. Showing a refined list of coupons.',
+            'type' => [
+                'label' => 'Discount type',
+                'all' => 'All types',
+                'percentage' => 'Percentage only',
+                'fixed' => 'Fixed amount only',
+            ],
+            'usage' => [
+                'label' => 'Usage limit',
+                'all' => 'All usage types',
+                'limited' => 'Limited only',
+                'unlimited' => 'Unlimited only',
+            ],
         ],
 
         'stats' => [
             'total' => 'Total coupons',
             'active' => 'Active coupons',
             'expired' => 'Expired coupons',
+            'expiring_soon' => 'Expiring soon',
+            'unlimited' => 'Unlimited coupons',
         ],
 
         'errors' => [

--- a/tests/Feature/AdminCouponIndexTest.php
+++ b/tests/Feature/AdminCouponIndexTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Coupon;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\Feature\Concerns\CreatesAdminTestData;
+use Tests\TestCase;
+
+class AdminCouponIndexTest extends TestCase
+{
+    use RefreshDatabase;
+    use CreatesAdminTestData;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Carbon::setTestNow(Carbon::create(2024, 1, 15, 12, 0, 0, 'UTC'));
+
+        app()->setLocale('en');
+
+        $admin = User::factory()->create();
+        $this->actingAs($admin);
+
+        $this->seedAdminReferenceData();
+    }
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    public function test_index_page_displays_enhanced_filters(): void
+    {
+        Coupon::factory()->create();
+
+        $response = $this->get(route('admin.coupons.index'));
+
+        $response->assertOk();
+        $response->assertSeeText(__('cms.coupons.filters.search_label'));
+        $response->assertSeeText(__('cms.coupons.filters.type.label'));
+        $response->assertSeeText(__('cms.coupons.filters.usage.label'));
+        $response->assertSeeText(__('cms.coupons.filters.expiring_soon'));
+    }
+
+    public function test_search_filter_restricts_results(): void
+    {
+        $matching = Coupon::factory()->create(['code' => 'SAVE2024']);
+        $nonMatching = Coupon::factory()->create(['code' => 'HELLO2024']);
+
+        $response = $this->get(route('admin.coupons.index', ['search' => 'SAVE']));
+
+        $response->assertOk();
+        $response->assertSeeText($matching->code);
+        $response->assertDontSeeText($nonMatching->code);
+    }
+
+    public function test_type_and_usage_filters_can_be_combined(): void
+    {
+        Coupon::factory()->create(['code' => 'PCT100', 'type' => 'percentage', 'usage_limit' => 100]);
+        Coupon::factory()->create(['code' => 'FIXED10', 'type' => 'fixed', 'usage_limit' => null]);
+
+        $response = $this->get(route('admin.coupons.index', ['type' => 'fixed', 'usage' => 'unlimited']));
+
+        $response->assertOk();
+        $response->assertSeeText('FIXED10');
+        $response->assertDontSeeText('PCT100');
+    }
+
+    public function test_expiring_soon_status_filter_only_shows_upcoming_expiries(): void
+    {
+        $soon = Coupon::factory()->create(['code' => 'SOON7', 'expires_at' => Carbon::now()->addDays(3)]);
+        $later = Coupon::factory()->create(['code' => 'LATER30', 'expires_at' => Carbon::now()->addMonths(2)]);
+        $expired = Coupon::factory()->create(['code' => 'EXPIRED', 'expires_at' => Carbon::now()->subDay()]);
+
+        $response = $this->get(route('admin.coupons.index', ['status' => 'expiring_soon']));
+
+        $response->assertOk();
+        $response->assertSeeText($soon->code);
+        $response->assertDontSeeText($later->code);
+        $response->assertDontSeeText($expired->code);
+    }
+
+    public function test_stats_include_expiring_and_unlimited_counts(): void
+    {
+        Coupon::factory()->create(['usage_limit' => null]);
+        Coupon::factory()->create(['usage_limit' => 10, 'expires_at' => Carbon::now()->addDays(2)]);
+
+        $response = $this->get(route('admin.coupons.index'));
+
+        $response->assertOk();
+        $response->assertSeeText(__('cms.coupons.stats.expiring_soon'));
+        $response->assertSeeText(__('cms.coupons.stats.unlimited'));
+    }
+}


### PR DESCRIPTION
## Summary
- extend the admin coupon index controller and Blade view with search, discount type, usage filters, expiring-soon status, richer stats, and usage progress indicators
- expand coupon seed data and localisation strings to cover new stats, filters, and badge labels
- add feature coverage for the coupon seeder and the upgraded admin listing, including new filtering scenarios

## Testing
- ⚠️ `php artisan test` *(fails before running because composer dependencies are unavailable without GitHub access)*
- ⚠️ `composer install` *(fails: GitHub 403 when attempting to fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_68e0423123f483299195bd5439735b5a