### PR TITLE
Refactor admin vendor management views

### DIFF
--- a/app/Support/Vendors/AdminVendorViewData.php
+++ b/app/Support/Vendors/AdminVendorViewData.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Support\Vendors;
+
+use App\Models\Vendor;
+
+class AdminVendorViewData
+{
+    public static function forIndex(): array
+    {
+        return [
+            'stats' => self::stats(),
+            'statusOptions' => self::statusOptions(),
+            'filters' => self::defaultFilters(),
+        ];
+    }
+
+    public static function forCreate(): array
+    {
+        return [
+            'statusOptions' => self::statusOptions(),
+            'defaultStatus' => 'active',
+        ];
+    }
+
+    public static function statusOptions(): array
+    {
+        return collect(Vendor::STATUSES)
+            ->mapWithKeys(fn (string $status) => [
+                $status => __('cms.vendors.status_' . $status),
+            ])
+            ->all();
+    }
+
+    public static function stats(): array
+    {
+        $statusCounts = Vendor::query()
+            ->selectRaw('status, COUNT(*) as aggregate')
+            ->groupBy('status')
+            ->pluck('aggregate', 'status');
+
+        $breakdown = collect(Vendor::STATUSES)
+            ->mapWithKeys(fn (string $status) => [
+                $status => (int) ($statusCounts[$status] ?? 0),
+            ])
+            ->all();
+
+        $total = (int) array_sum($breakdown);
+
+        $percentages = collect($breakdown)
+            ->map(fn (int $count) => $total > 0 ? (int) round(($count / $total) * 100) : 0)
+            ->all();
+
+        return [
+            'total' => $total,
+            'breakdown' => $breakdown,
+            'percentages' => $percentages,
+        ];
+    }
+
+    public static function defaultFilters(): array
+    {
+        return [
+            'status' => '',
+            'search' => '',
+        ];
+    }
+}

--- a/resources/views/admin/vendors/create.blade.php
+++ b/resources/views/admin/vendors/create.blade.php
@@ -10,142 +10,24 @@
     </x-admin.button-link>
 </x-admin.page-header>
 
-<x-admin.card class="mt-6">
-    <form action="{{ route('admin.vendors.store') }}" method="POST" class="grid gap-6">
-        @csrf
-
-        <div class="grid gap-6 lg:grid-cols-2">
-            <div class="space-y-4">
-                <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">{{ __('cms.vendors.vendor_details_heading') }}</h3>
-
-                <div class="grid gap-4">
-                    <div>
-                        <label for="name" class="form-label">{{ __('cms.vendors.vendor_name') }}</label>
-                        <input
-                            id="name"
-                            type="text"
-                            name="name"
-                            value="{{ old('name') }}"
-                            maxlength="255"
-                            class="form-control @error('name') is-invalid @enderror"
-                            autocomplete="name"
-                            required
-                        >
-                        @error('name')
-                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
-                        @enderror
-                    </div>
-
-                    <div>
-                        <label for="email" class="form-label">{{ __('cms.vendors.vendor_email') }}</label>
-                        <input
-                            id="email"
-                            type="email"
-                            name="email"
-                            value="{{ old('email') }}"
-                            maxlength="255"
-                            class="form-control @error('email') is-invalid @enderror"
-                            autocomplete="email"
-                            required
-                        >
-                        @error('email')
-                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
-                        @enderror
-                    </div>
-
-                    <div>
-                        <label for="phone" class="form-label">{{ __('cms.vendors.phone_optional') }}</label>
-                        <input
-                            id="phone"
-                            type="text"
-                            name="phone"
-                            value="{{ old('phone') }}"
-                            maxlength="20"
-                            class="form-control @error('phone') is-invalid @enderror"
-                            autocomplete="tel"
-                            inputmode="tel"
-                            placeholder="+1 555 123 4567"
-                            aria-describedby="phone-help"
-                        >
-                        <p id="phone-help" class="form-text text-xs text-gray-500 mt-1">
-                            {{ __('cms.vendors.phone_format_hint') }}
-                        </p>
-                        @error('phone')
-                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
-                        @enderror
-                    </div>
-                </div>
-            </div>
-
-            <div class="space-y-4">
-                <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">{{ __('cms.vendors.account_security_heading') }}</h3>
-
-                <div class="grid gap-4">
-                    <div>
-                        <label for="password" class="form-label">{{ __('cms.vendors.password') }}</label>
-                        <input
-                            id="password"
-                            type="password"
-                            name="password"
-                            class="form-control @error('password') is-invalid @enderror"
-                            autocomplete="new-password"
-                            required
-                            aria-describedby="password-help"
-                        >
-                        <p id="password-help" class="form-text text-xs text-gray-500 mt-1">
-                            {{ __('cms.vendors.password_requirements') }}
-                        </p>
-                        @error('password')
-                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
-                        @enderror
-                    </div>
-
-                    <div>
-                        <label for="password_confirmation" class="form-label">{{ __('cms.vendors.confirm_password') }}</label>
-                        <input
-                            id="password_confirmation"
-                            type="password"
-                            name="password_confirmation"
-                            class="form-control @error('password_confirmation') is-invalid @enderror"
-                            autocomplete="new-password"
-                            required
-                        >
-                        @error('password_confirmation')
-                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
-                        @enderror
-                    </div>
-
-                    <div>
-                        <label for="status" class="form-label">{{ __('cms.vendors.status_label') }}</label>
-                        <select
-                            id="status"
-                            name="status"
-                            class="form-select @error('status') is-invalid @enderror"
-                            required
-                        >
-                            <option value="" disabled {{ old('status') ? '' : 'selected' }}>{{ __('cms.vendors.status_placeholder') }}</option>
-                            @foreach ($statusOptions as $value => $label)
-                                <option value="{{ $value }}" @selected(old('status', 'active') === $value)>
-                                    {{ $label }}
-                                </option>
-                            @endforeach
-                        </select>
-                        @error('status')
-                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
-                        @enderror
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="flex flex-wrap justify-end gap-3">
-            <button type="submit" class="btn btn-primary">
-                {{ __('cms.vendors.register_button') }}
-            </button>
-            <x-admin.button-link href="{{ route('admin.vendors.index') }}" class="btn-outline">
-                {{ __('cms.vendors.cancel_button') }}
-            </x-admin.button-link>
-        </div>
-    </form>
-</x-admin.card>
+@include('admin.vendors.partials.form', [
+    'action' => route('admin.vendors.store'),
+    'statusOptions' => $statusOptions,
+    'defaultStatus' => $defaultStatus ?? 'active',
+    'cancelRoute' => route('admin.vendors.index'),
+])
 @endsection
+
+@push('scripts')
+    <script>
+        document.addEventListener('DOMContentLoaded', () => {
+            document.querySelectorAll('[data-trim]').forEach((input) => {
+                input.addEventListener('blur', () => {
+                    if (typeof input.value === 'string') {
+                        input.value = input.value.trim();
+                    }
+                });
+            });
+        });
+    </script>
+@endpush

--- a/resources/views/admin/vendors/partials/form.blade.php
+++ b/resources/views/admin/vendors/partials/form.blade.php
@@ -1,0 +1,167 @@
+@props([
+    'action',
+    'method' => 'POST',
+    'statusOptions' => [],
+    'defaultStatus' => 'active',
+    'cancelRoute' => null,
+])
+
+@php
+    $selectedStatus = old('status', $defaultStatus);
+    $cancelRoute ??= route('admin.vendors.index');
+@endphp
+
+<x-admin.card class="mt-6">
+    <form action="{{ $action }}" method="POST" class="grid gap-6">
+        @csrf
+        @unless (in_array(strtoupper($method), ['GET', 'POST'], true))
+            @method($method)
+        @endunless
+
+        <div class="grid gap-6 lg:grid-cols-2">
+            <section class="space-y-5">
+                <header class="space-y-1">
+                    <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">{{ __('cms.vendors.vendor_details_heading') }}</h3>
+                </header>
+
+                <div class="grid gap-5">
+                    <div class="grid gap-2">
+                        <label for="name" class="form-label">{{ __('cms.vendors.vendor_name') }}</label>
+                        <input
+                            id="name"
+                            type="text"
+                            name="name"
+                            value="{{ old('name') }}"
+                            maxlength="255"
+                            minlength="2"
+                            data-trim
+                            class="form-control @error('name') is-invalid @enderror"
+                            autocomplete="name"
+                            required
+                        >
+                        @error('name')
+                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div class="grid gap-2">
+                        <label for="email" class="form-label">{{ __('cms.vendors.vendor_email') }}</label>
+                        <input
+                            id="email"
+                            type="email"
+                            name="email"
+                            value="{{ old('email') }}"
+                            maxlength="255"
+                            data-trim
+                            class="form-control @error('email') is-invalid @enderror"
+                            autocomplete="email"
+                            inputmode="email"
+                            required
+                        >
+                        @error('email')
+                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div class="grid gap-2">
+                        <label for="phone" class="form-label">{{ __('cms.vendors.phone_optional') }}</label>
+                        <input
+                            id="phone"
+                            type="text"
+                            name="phone"
+                            value="{{ old('phone') }}"
+                            maxlength="20"
+                            data-trim
+                            pattern="^[0-9+()\\s-]{7,20}$"
+                            class="form-control @error('phone') is-invalid @enderror"
+                            autocomplete="tel"
+                            inputmode="tel"
+                            placeholder="+1 555 123 4567"
+                            aria-describedby="phone-help"
+                        >
+                        <p id="phone-help" class="form-text text-xs text-gray-500 mt-1">
+                            {{ __('cms.vendors.phone_format_hint') }}
+                        </p>
+                        @error('phone')
+                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+                </div>
+            </section>
+
+            <section class="space-y-5">
+                <header class="space-y-1">
+                    <h3 class="text-sm font-semibold text-gray-700 uppercase tracking-wide">{{ __('cms.vendors.account_security_heading') }}</h3>
+                </header>
+
+                <div class="grid gap-5">
+                    <div class="grid gap-2">
+                        <label for="password" class="form-label">{{ __('cms.vendors.password') }}</label>
+                        <input
+                            id="password"
+                            type="password"
+                            name="password"
+                            class="form-control @error('password') is-invalid @enderror"
+                            autocomplete="new-password"
+                            minlength="8"
+                            pattern="^(?=.*[\\W_]).{8,}$"
+                            title="{{ __('cms.vendors.password_requirements') }}"
+                            required
+                        >
+                        <p id="password-help" class="form-text text-xs text-gray-500 mt-1">
+                            {{ __('cms.vendors.password_requirements') }}
+                        </p>
+                        @error('password')
+                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div class="grid gap-2">
+                        <label for="password_confirmation" class="form-label">{{ __('cms.vendors.confirm_password') }}</label>
+                        <input
+                            id="password_confirmation"
+                            type="password"
+                            name="password_confirmation"
+                            class="form-control @error('password_confirmation') is-invalid @enderror"
+                            autocomplete="new-password"
+                            minlength="8"
+                            pattern="^(?=.*[\\W_]).{8,}$"
+                            title="{{ __('cms.vendors.password_requirements') }}"
+                            required
+                        >
+                        @error('password_confirmation')
+                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+
+                    <div class="grid gap-2">
+                        <label for="status" class="form-label">{{ __('cms.vendors.status_label') }}</label>
+                        <select
+                            id="status"
+                            name="status"
+                            class="form-select @error('status') is-invalid @enderror"
+                            required
+                        >
+                            <option value="" disabled {{ $selectedStatus ? '' : 'selected' }}>{{ __('cms.vendors.status_placeholder') }}</option>
+                            @foreach ($statusOptions as $value => $label)
+                                <option value="{{ $value }}" @selected($selectedStatus === $value)>{{ $label }}</option>
+                            @endforeach
+                        </select>
+                        @error('status')
+                            <p class="text-sm text-danger mt-1">{{ $message }}</p>
+                        @enderror
+                    </div>
+                </div>
+            </section>
+        </div>
+
+        <div class="flex flex-wrap justify-end gap-3">
+            <button type="submit" class="btn btn-primary">
+                {{ __('cms.vendors.register_button') }}
+            </button>
+            <x-admin.button-link href="{{ $cancelRoute }}" class="btn-outline">
+                {{ __('cms.vendors.cancel_button') }}
+            </x-admin.button-link>
+        </div>
+    </form>
+</x-admin.card>

--- a/resources/views/components/admin/stat-card.blade.php
+++ b/resources/views/components/admin/stat-card.blade.php
@@ -1,0 +1,50 @@
+@props([
+    'label',
+    'value' => 0,
+    'variant' => 'slate',
+    'percentage' => null,
+])
+
+@php
+    $variants = [
+        'slate' => [
+            'wrapper' => 'bg-slate-50 border border-slate-200 text-slate-900',
+            'label' => 'text-slate-600',
+            'progress' => 'bg-slate-400',
+        ],
+        'emerald' => [
+            'wrapper' => 'bg-emerald-50 border border-emerald-100 text-emerald-900',
+            'label' => 'text-emerald-600',
+            'progress' => 'bg-emerald-500',
+        ],
+        'amber' => [
+            'wrapper' => 'bg-amber-50 border border-amber-100 text-amber-900',
+            'label' => 'text-amber-600',
+            'progress' => 'bg-amber-500',
+        ],
+        'rose' => [
+            'wrapper' => 'bg-rose-50 border border-rose-100 text-rose-900',
+            'label' => 'text-rose-600',
+            'progress' => 'bg-rose-500',
+        ],
+    ];
+
+    $styles = $variants[$variant] ?? $variants['slate'];
+@endphp
+
+<div class="p-4 rounded-lg {{ $styles['wrapper'] }}">
+    <p class="text-xs uppercase tracking-wide {{ $styles['label'] }} mb-1">{{ $label }}</p>
+    <p class="text-xl font-semibold leading-tight">{{ $value }}</p>
+
+    @if(! is_null($percentage))
+        <div class="mt-3" role="presentation">
+            <div class="h-2 rounded-full bg-white/60 overflow-hidden" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="{{ $percentage }}">
+                <div class="h-full {{ $styles['progress'] }}" style="width: {{ max(min($percentage, 100), 0) }}%;"></div>
+            </div>
+            <p class="mt-2 text-[11px] font-medium {{ $styles['label'] }}" title="{{ $percentage }}% {{ __('cms.vendors.total_vendors') }}">
+                {{ $percentage }}%
+                <span class="sr-only">{{ __('cms.vendors.total_vendors') }}</span>
+            </p>
+        </div>
+    @endif
+</div>

--- a/tests/Feature/AdminVendorManagementTest.php
+++ b/tests/Feature/AdminVendorManagementTest.php
@@ -13,6 +13,42 @@ class AdminVendorManagementTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
+    public function admin_can_view_vendor_index_with_stats_and_filters(): void
+    {
+        Vendor::factory()->create(['status' => 'inactive']);
+
+        $response = $this->get(route('admin.vendors.index'));
+
+        $response->assertOk();
+        $response->assertViewIs('admin.vendors.index');
+        $response->assertViewHas('stats', function ($stats) {
+            return is_array($stats)
+                && array_key_exists('total', $stats)
+                && isset($stats['breakdown'])
+                && isset($stats['percentages'])
+                && array_key_exists('active', $stats['breakdown'])
+                && array_key_exists('inactive', $stats['breakdown'])
+                && array_key_exists('banned', $stats['breakdown'])
+                && array_key_exists('active', $stats['percentages'])
+                && array_key_exists('inactive', $stats['percentages'])
+                && array_key_exists('banned', $stats['percentages']);
+        });
+
+        $response->assertViewHas('statusOptions', function ($options) {
+            return is_array($options)
+                && array_key_exists('active', $options)
+                && array_key_exists('inactive', $options)
+                && array_key_exists('banned', $options);
+        });
+
+        $response->assertViewHas('filters', function ($filters) {
+            return is_array($filters)
+                && array_key_exists('status', $filters)
+                && array_key_exists('search', $filters);
+        });
+    }
+
+    /** @test */
     public function admin_can_view_vendor_create_form(): void
     {
         $response = $this->get(route('admin.vendors.create'));

--- a/tests/Unit/AdminVendorViewDataTest.php
+++ b/tests/Unit/AdminVendorViewDataTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Vendor;
+use App\Support\Vendors\AdminVendorViewData;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AdminVendorViewDataTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function it_builds_index_view_data_with_stats_and_filters(): void
+    {
+        Vendor::factory()->count(2)->create(['status' => 'active']);
+        Vendor::factory()->create(['status' => 'banned']);
+
+        $viewData = AdminVendorViewData::forIndex();
+        $stats = $viewData['stats'];
+
+        $this->assertSame(3, $stats['total']);
+        $this->assertSame(2, $stats['breakdown']['active']);
+        $this->assertSame(0, $stats['breakdown']['inactive']);
+        $this->assertSame(1, $stats['breakdown']['banned']);
+        $this->assertSame(67, $stats['percentages']['active']);
+        $this->assertSame(0, $stats['percentages']['inactive']);
+        $this->assertSame(33, $stats['percentages']['banned']);
+
+        $this->assertArrayHasKey('active', $viewData['statusOptions']);
+        $this->assertSame(['status' => '', 'search' => ''], $viewData['filters']);
+    }
+
+    /** @test */
+    public function it_provides_form_defaults_for_create_view(): void
+    {
+        $formData = AdminVendorViewData::forCreate();
+
+        $this->assertSame('active', $formData['defaultStatus']);
+        $this->assertArrayHasKey('inactive', $formData['statusOptions']);
+        $this->assertArrayHasKey('banned', $formData['statusOptions']);
+    }
+}


### PR DESCRIPTION
## Summary
- extract reusable AdminVendorViewData helper to provide stats, filters, and status options for vendor pages
- redesign the admin vendor index with stat cards, search and resettable filters, and shared UI components
- move the vendor create form into a reusable partial with stronger client-side constraints and input trimming
- add a Blade stat card component plus unit and feature coverage for the new view data

## Testing
- php artisan test *(fails: composer install cannot reach GitHub over the network, so dependencies are unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68e0430deacc8329a1262e7fdee76527