### PR TITLE
Refactor admin payments UI and filtering

### DIFF
--- a/lang/en/cms.php
+++ b/lang/en/cms.php
@@ -323,7 +323,10 @@ return [
 
         // Page Titles
         'title' => 'Payments',
-        'details_title' => 'Payment Details',
+        'index_description' => 'Monitor incoming transactions, filter by gateway, and keep tabs on the latest activity.',
+        'details_title' => 'Payment details',
+        'details_heading' => 'Payment #:id',
+        'details_description' => 'Review the transaction metadata, associated order, and payout destinations.',
 
         // Table Headings
         'id' => 'ID',
@@ -336,6 +339,7 @@ return [
         'action' => 'Action',
         'shops' => 'Shops',
 
+        // Filters
         'filters_heading' => 'Filter payments',
         'filters_all_statuses' => 'All statuses',
         'filters_all_gateways' => 'All gateways',
@@ -349,22 +353,37 @@ return [
         'completed' => 'Completed',
         'pending' => 'Pending',
         'failed' => 'Failed',
+        'processing' => 'Processing',
+        'refunded' => 'Refunded',
+
+        // Metrics & Empty State
+        'empty_state' => 'No payments match your filters yet.',
+        'metric_total' => 'Payments',
+        'metric_total_hint' => 'Total transactions that match your filters.',
+        'metric_completed' => 'Completed',
+        'metric_completed_hint' => 'Successful payments in the current view.',
+        'metric_failed' => 'Failed',
+        'metric_failed_hint' => 'Payments that may require follow-up.',
+
+        // Actions
+        'view_details' => 'View details',
 
         // Delete Modal
-        'delete_confirm' => 'Confirm Delete',
-        'delete_message' => 'Are you sure you want to delete this payment?',
+        'delete_confirm_title' => 'Confirm deletion',
+        'delete_confirm_message' => 'Are you sure you want to delete this payment?',
         'cancel' => 'Cancel',
         'delete' => 'Delete',
 
         // Alerts / Notifications
         'success' => 'Success',
-        'deleted' => 'Deleted',
+        'deleted' => 'Payment deleted successfully.',
         'delete_error' => 'Error deleting payment!',
 
         // Payment Details Page
         'transaction_id' => 'Transaction ID',
-        'created_at' => 'Created At',
-        'back' => 'Back to Payments',
+        'created_at' => 'Created at',
+        'back' => 'Back to payments',
+        'status_hint' => 'Status reflects the latest update received from the payment gateway.',
 
         // Fallback
         'not_available' => 'N/A',

--- a/resources/js/admin/payments/index.js
+++ b/resources/js/admin/payments/index.js
@@ -1,0 +1,170 @@
+import axios from 'axios';
+
+const getCsrfToken = () => {
+    const meta = document.querySelector('meta[name="csrf-token"]');
+    return meta ? meta.getAttribute('content') : '';
+};
+
+const showToast = (type, message, title) => {
+    if (!window.toastr) {
+        return;
+    }
+
+    const toast = window.toastr[type] ?? window.toastr.info;
+    toast(message, title, {
+        closeButton: true,
+        progressBar: true,
+        positionClass: 'toast-top-right',
+        timeOut: 5000,
+    });
+};
+
+const createEmptyRow = (tableElement) => {
+    const tableBody = tableElement?.querySelector('tbody');
+    if (!tableBody) {
+        return null;
+    }
+
+    const emptyMessage = tableElement.dataset.emptyMessage ?? '';
+    const columnCountValue = tableElement.dataset.columnCount ?? '1';
+    const columnCount = Number.parseInt(columnCountValue, 10);
+
+    const emptyRow = document.createElement('tr');
+    emptyRow.dataset.paymentsEmptyRow = '';
+
+    const emptyCell = document.createElement('td');
+    emptyCell.colSpan = Number.isNaN(columnCount) ? 1 : columnCount;
+    emptyCell.className = 'table-cell py-6 text-center text-sm text-gray-500';
+    emptyCell.textContent = emptyMessage;
+
+    emptyRow.appendChild(emptyCell);
+    return emptyRow;
+};
+
+const removePaymentRow = (paymentId) => {
+    const deleteButton = document.querySelector(`[data-payment-delete="${paymentId}"]`);
+    const row = deleteButton?.closest('tr');
+
+    if (!row) {
+        window.location.reload();
+        return;
+    }
+
+    const tableBody = row.parentElement;
+    row.remove();
+
+    if (!tableBody) {
+        return;
+    }
+
+    if (tableBody.children.length === 0) {
+        const table = tableBody.closest('[data-payments-table]');
+        const emptyRow = createEmptyRow(table);
+        if (emptyRow) {
+            tableBody.appendChild(emptyRow);
+        }
+    }
+};
+
+const initializePaymentsModule = () => {
+    const modal = document.querySelector('[data-payment-delete-modal]');
+    if (!modal) {
+        return;
+    }
+
+    const confirmButton = modal.querySelector('[data-confirm-delete]');
+    const dismissButtons = modal.querySelectorAll('[data-dismiss-modal]');
+    const labelElement = modal.querySelector('[data-payment-label]');
+    const deleteUrlTemplate = modal.dataset.deleteUrl;
+    const successTitle = modal.dataset.successTitle;
+    const successMessage = modal.dataset.successMessage;
+    const errorTitle = modal.dataset.errorTitle;
+    const errorMessage = modal.dataset.errorMessage;
+
+    let currentPaymentId = null;
+
+    const hideModal = () => {
+        modal.classList.add('hidden');
+        currentPaymentId = null;
+        if (labelElement) {
+            labelElement.textContent = '';
+        }
+        if (confirmButton) {
+            confirmButton.disabled = false;
+        }
+    };
+
+    const showModal = () => {
+        modal.classList.remove('hidden');
+    };
+
+    dismissButtons.forEach((button) => {
+        button.addEventListener('click', hideModal);
+    });
+
+    modal.addEventListener('click', (event) => {
+        if (event.target === modal) {
+            hideModal();
+        }
+    });
+
+    document.addEventListener('keydown', (event) => {
+        if (event.key === 'Escape' && !modal.classList.contains('hidden')) {
+            hideModal();
+        }
+    });
+
+    document.addEventListener('click', (event) => {
+        const trigger = event.target.closest?.('[data-payment-delete]');
+        if (!trigger) {
+            return;
+        }
+
+        currentPaymentId = trigger.dataset.paymentDelete ?? null;
+        const paymentLabel = trigger.dataset.paymentLabel ?? '';
+
+        if (labelElement) {
+            labelElement.textContent = paymentLabel;
+        }
+
+        showModal();
+    });
+
+    if (!confirmButton || !deleteUrlTemplate) {
+        return;
+    }
+
+    confirmButton.addEventListener('click', async () => {
+        if (!currentPaymentId) {
+            return;
+        }
+
+        confirmButton.disabled = true;
+
+        const csrfToken = getCsrfToken();
+        const deleteUrl = deleteUrlTemplate.replace('__PAYMENT_ID__', currentPaymentId);
+
+        try {
+            const response = await axios.delete(deleteUrl, {
+                data: {
+                    _token: csrfToken,
+                },
+            });
+
+            if (response.data?.success) {
+                removePaymentRow(currentPaymentId);
+                showToast('success', response.data?.message ?? successMessage, successTitle);
+                hideModal();
+            } else {
+                showToast('error', response.data?.message ?? errorMessage, errorTitle);
+            }
+        } catch (error) {
+            console.error('Failed to delete payment', error);
+            showToast('error', errorMessage, errorTitle);
+        } finally {
+            confirmButton.disabled = false;
+        }
+    });
+};
+
+document.addEventListener('DOMContentLoaded', initializePaymentsModule);

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -3,6 +3,7 @@ import './admin/sidebar';
 import './admin/orders/index';
 import './admin/coupons/index';
 import './admin/customers/index';
+import './admin/payments/index';
 
 document.addEventListener('click', function (event) {
     const target = event.target;

--- a/resources/views/admin/payments/index.blade.php
+++ b/resources/views/admin/payments/index.blade.php
@@ -1,220 +1,230 @@
 @extends('admin.layouts.admin')
 
+@php
+    $deleteTemplate = route('admin.payments.destroy', ['payment' => '__PAYMENT_ID__']);
+@endphp
+
 @section('content')
-    <div class="card mt-4">
-        <div class="card-header card-header-bg text-white">
-            <h6 class="d-flex align-items-center mb-0 dt-heading">{{ __('cms.payments.title') }}</h6>
-        </div>
+    <x-admin.page-header
+        :title="__('cms.payments.title')"
+        :description="__('cms.payments.index_description')"
+    />
 
-        <div class="card-body">
-            <div class="border rounded-3 p-3 p-lg-4 bg-light-subtle mb-4">
-                <h6 class="mb-3 text-muted">{{ __('cms.payments.filters_heading') }}</h6>
-                <form id="payment-filters" class="row g-3">
-                    <div class="col-12 col-md-6 col-xl-3">
-                        <label for="filterStatus" class="form-label">{{ __('cms.payments.status') }}</label>
-                        <select id="filterStatus" class="form-select">
-                            <option value="">{{ __('cms.payments.filters_all_statuses') }}</option>
-                            @foreach ($statusOptions as $value => $label)
-                                <option value="{{ $value }}">{{ $label }}</option>
-                            @endforeach
-                        </select>
-                    </div>
-                    <div class="col-12 col-md-6 col-xl-3">
-                        <label for="filterGateway" class="form-label">{{ __('cms.payment_gateways.title') }}</label>
-                        <select id="filterGateway" class="form-select">
-                            <option value="">{{ __('cms.payments.filters_all_gateways') }}</option>
-                            @foreach ($gateways as $gateway)
-                                <option value="{{ $gateway->id }}">{{ $gateway->name }}</option>
-                            @endforeach
-                        </select>
-                    </div>
-                    <div class="col-12 col-md-6 col-xl-3">
-                        <label for="filterShop" class="form-label">{{ __('cms.payments.shops') }}</label>
-                        <select id="filterShop" class="form-select">
-                            <option value="">{{ __('cms.payments.filters_all_shops') }}</option>
-                            @foreach ($shops as $shop)
-                                <option value="{{ $shop->id }}">{{ $shop->name }}</option>
-                            @endforeach
-                        </select>
-                    </div>
-                    <div class="col-12 col-md-6 col-xl-3">
-                        <label for="filterDateFrom" class="form-label">{{ __('cms.payments.filters_date_from') }}</label>
-                        <input type="date" id="filterDateFrom" class="form-control">
-                    </div>
-                    <div class="col-12 col-md-6 col-xl-3">
-                        <label for="filterDateTo" class="form-label">{{ __('cms.payments.filters_date_to') }}</label>
-                        <input type="date" id="filterDateTo" class="form-control">
-                    </div>
-                    <div class="col-12 col-md-6 col-xl-3 d-flex align-items-end gap-2">
-                        <button type="submit" class="btn btn-primary flex-grow-1">{{ __('cms.payments.filters_apply') }}</button>
-                        <button type="button" class="btn btn-outline-secondary" id="resetFilters">{{ __('cms.payments.filters_reset') }}</button>
-                    </div>
-                </form>
+    <x-admin.card class="mt-6">
+        <div class="grid gap-6">
+            <form method="GET" action="{{ route('admin.payments.index') }}" class="grid gap-4 md:grid-cols-2 xl:grid-cols-3">
+                <div>
+                    <label for="filter-status" class="form-label">{{ __('cms.payments.status') }}</label>
+                    <select id="filter-status" name="status" class="form-select">
+                        <option value="">{{ __('cms.payments.filters_all_statuses') }}</option>
+                        @foreach ($statusOptions as $value => $label)
+                            <option value="{{ $value }}" @selected($filters['status'] === $value)>
+                                {{ $label }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+
+                <div>
+                    <label for="filter-gateway" class="form-label">{{ __('cms.payment_gateways.title') }}</label>
+                    <select id="filter-gateway" name="gateway_id" class="form-select">
+                        <option value="">{{ __('cms.payments.filters_all_gateways') }}</option>
+                        @foreach ($gateways as $gateway)
+                            <option value="{{ $gateway->id }}" @selected($filters['gateway_id'] === (string) $gateway->id)>
+                                {{ $gateway->name }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+
+                <div>
+                    <label for="filter-shop" class="form-label">{{ __('cms.payments.shops') }}</label>
+                    <select id="filter-shop" name="shop_id" class="form-select">
+                        <option value="">{{ __('cms.payments.filters_all_shops') }}</option>
+                        @foreach ($shops as $shop)
+                            <option value="{{ $shop->id }}" @selected($filters['shop_id'] === (string) $shop->id)>
+                                {{ $shop->name }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+
+                <div>
+                    <label for="filter-date-from" class="form-label">{{ __('cms.payments.filters_date_from') }}</label>
+                    <input
+                        id="filter-date-from"
+                        type="date"
+                        name="date_from"
+                        value="{{ $filters['date_from'] }}"
+                        class="form-control"
+                    >
+                </div>
+
+                <div>
+                    <label for="filter-date-to" class="form-label">{{ __('cms.payments.filters_date_to') }}</label>
+                    <input
+                        id="filter-date-to"
+                        type="date"
+                        name="date_to"
+                        value="{{ $filters['date_to'] }}"
+                        class="form-control"
+                    >
+                </div>
+
+                <div class="flex items-end gap-3">
+                    <button type="submit" class="btn btn-primary w-full md:w-auto">
+                        {{ __('cms.payments.filters_apply') }}
+                    </button>
+                    <a href="{{ route('admin.payments.index') }}" class="btn btn-outline w-full md:w-auto">
+                        {{ __('cms.payments.filters_reset') }}
+                    </a>
+                </div>
+            </form>
+
+            <div class="grid gap-4 sm:grid-cols-3">
+                <div class="rounded-xl border border-gray-200 bg-white p-4">
+                    <p class="text-sm font-medium text-gray-500">{{ __('cms.payments.metric_total') }}</p>
+                    <p class="mt-2 text-2xl font-semibold text-gray-900">{{ number_format($metrics['total']) }}</p>
+                    <p class="mt-1 text-xs text-gray-500">{{ __('cms.payments.metric_total_hint') }}</p>
+                </div>
+                <div class="rounded-xl border border-gray-200 bg-white p-4">
+                    <p class="text-sm font-medium text-gray-500">{{ __('cms.payments.metric_completed') }}</p>
+                    <p class="mt-2 text-2xl font-semibold text-gray-900">{{ number_format($metrics['completed']) }}</p>
+                    <p class="mt-1 text-xs text-gray-500">{{ __('cms.payments.metric_completed_hint') }}</p>
+                </div>
+                <div class="rounded-xl border border-gray-200 bg-white p-4">
+                    <p class="text-sm font-medium text-gray-500">{{ __('cms.payments.metric_failed') }}</p>
+                    <p class="mt-2 text-2xl font-semibold text-gray-900">{{ number_format($metrics['failed']) }}</p>
+                    <p class="mt-1 text-xs text-gray-500">{{ __('cms.payments.metric_failed_hint') }}</p>
+                </div>
             </div>
 
-            <div class="table-responsive">
-                <table id="payments-table" class="table table-bordered table-striped align-middle w-100">
-                    <thead>
-                        <tr>
-                            <th>{{ __('cms.payments.id') }}</th>
-                            <th>{{ __('cms.payments.order') }}</th>
-                            <th>{{ __('cms.payments.user') }}</th>
-                            <th>{{ __('cms.payments.shops') }}</th>
-                            <th>{{ __('cms.payments.gateway') }}</th>
-                            <th>{{ __('cms.payments.amount') }}</th>
-                            <th>{{ __('cms.payments.status') }}</th>
-                            <th>{{ __('cms.payments.created_at') }}</th>
-                            <th>{{ __('cms.payments.transaction') }}</th>
-                            <th>{{ __('cms.payments.action') }}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        <!-- DataTables will populate the body -->
-                    </tbody>
-                </table>
+            <x-admin.table
+                data-payments-table
+                data-column-count="10"
+                data-empty-message="{{ __('cms.payments.empty_state') }}"
+                :columns="[
+                    __('cms.payments.id'),
+                    __('cms.payments.order'),
+                    __('cms.payments.user'),
+                    __('cms.payments.shops'),
+                    __('cms.payments.gateway'),
+                    __('cms.payments.amount'),
+                    __('cms.payments.status'),
+                    __('cms.payments.transaction'),
+                    __('cms.payments.created_at'),
+                    __('cms.payments.action'),
+                ]"
+            >
+                @forelse ($payments as $payment)
+                    <tr class="table-row" data-payment-row="{{ $payment->id }}">
+                        <td class="table-cell font-semibold">#{{ $payment->id }}</td>
+                        <td class="table-cell">
+                            @if ($payment->order)
+                                <a href="{{ route('admin.orders.show', $payment->order) }}" class="text-primary-600 hover:text-primary-700">
+                                    #{{ $payment->order->id }}
+                                </a>
+                            @else
+                                <span class="text-gray-500">{{ __('cms.payments.not_available') }}</span>
+                            @endif
+                        </td>
+                        <td class="table-cell">
+                            {{ $payment->customer_display_name ?? __('cms.payments.not_available') }}
+                        </td>
+                        <td class="table-cell">
+                            @if (!empty($payment->shop_names))
+                                <div class="flex flex-wrap gap-1">
+                                    @foreach ($payment->shop_names as $shopName)
+                                        <span class="badge badge-gray">{{ $shopName }}</span>
+                                    @endforeach
+                                </div>
+                            @else
+                                <span class="text-gray-500">{{ __('cms.payments.not_available') }}</span>
+                            @endif
+                        </td>
+                        <td class="table-cell">{{ $payment->gateway->name ?? __('cms.payments.not_available') }}</td>
+                        <td class="table-cell font-semibold text-gray-900">
+                            {{ number_format((float) $payment->amount, 2) }}
+                            @if ($payment->currency)
+                                <span class="text-xs text-gray-500">{{ $payment->currency }}</span>
+                            @endif
+                        </td>
+                        <td class="table-cell">
+                            @php
+                                $statusKey = $payment->status ?? 'unknown';
+                                $badgeClass = $statusBadges[$statusKey] ?? 'badge badge-gray';
+                                $translationKey = 'cms.payments.' . $statusKey;
+                                $statusLabel = __($translationKey);
+
+                                if ($statusLabel === $translationKey) {
+                                    $statusLabel = ucfirst(str_replace('_', ' ', (string) $statusKey));
+                                }
+                            @endphp
+                            <span class="{{ $badgeClass }}">{{ $statusLabel }}</span>
+                        </td>
+                        <td class="table-cell">{{ $payment->transaction_id ?? __('cms.payments.not_available') }}</td>
+                        <td class="table-cell">{{ optional($payment->created_at)->format('d M Y, h:i A') ?? __('cms.payments.not_available') }}</td>
+                        <td class="table-cell">
+                            <div class="flex flex-wrap gap-2">
+                                <a href="{{ route('admin.payments.show', $payment) }}" class="btn btn-sm btn-outline">
+                                    {{ __('cms.payments.view_details') }}
+                                </a>
+                                <button
+                                    type="button"
+                                    class="btn btn-sm btn-outline-danger"
+                                    data-payment-delete="{{ $payment->id }}"
+                                    data-payment-label="#{{ $payment->id }}"
+                                >
+                                    {{ __('cms.payments.delete') }}
+                                </button>
+                            </div>
+                        </td>
+                    </tr>
+                @empty
+                    <tr data-payments-empty-row>
+                        <td colspan="10" class="table-cell py-6 text-center text-sm text-gray-500">
+                            {{ __('cms.payments.empty_state') }}
+                        </td>
+                    </tr>
+                @endforelse
+            </x-admin.table>
+
+            @if ($payments->hasPages())
+                <div>
+                    {{ $payments->links() }}
+                </div>
+            @endif
+        </div>
+    </x-admin.card>
+
+    <div
+        data-payment-delete-modal
+        data-delete-url="{{ $deleteTemplate }}"
+        data-success-title="{{ __('cms.notifications.success') }}"
+        data-success-message="{{ __('cms.payments.deleted') }}"
+        data-error-title="{{ __('cms.notifications.error') }}"
+        data-error-message="{{ __('cms.payments.delete_error') }}"
+        class="fixed inset-0 z-50 hidden"
+    >
+        <div class="absolute inset-0 bg-gray-900/50" data-dismiss-modal></div>
+        <div class="relative z-10 flex min-h-full items-center justify-center p-4">
+            <div class="w-full max-w-md overflow-hidden rounded-2xl bg-white shadow-xl">
+                <div class="border-b border-gray-200 px-6 py-4">
+                    <h2 class="text-base font-semibold text-gray-900">{{ __('cms.payments.delete_confirm_title') }}</h2>
+                </div>
+                <div class="px-6 py-5">
+                    <p class="text-sm text-gray-600">{{ __('cms.payments.delete_confirm_message') }}</p>
+                    <p class="mt-2 text-sm font-semibold text-gray-900" data-payment-label></p>
+                </div>
+                <div class="flex items-center justify-end gap-3 border-t border-gray-200 bg-gray-50 px-6 py-4">
+                    <button type="button" class="btn btn-outline" data-dismiss-modal>
+                        {{ __('cms.payments.cancel') }}
+                    </button>
+                    <button type="button" class="btn btn-danger" data-confirm-delete>
+                        {{ __('cms.payments.delete') }}
+                    </button>
+                </div>
             </div>
         </div>
     </div>
-
-    <!-- Delete Modal -->
-    <div class="modal fade" id="deletePaymentModal" tabindex="-1" aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <h5 class="modal-title">{{ __('cms.payments.delete_confirm') }}</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                </div>
-                <div class="modal-body">{{ __('cms.payments.delete_message') }}</div>
-                <div class="modal-footer">
-                    <button type="button" class="btn btn-secondary"
-                            data-bs-dismiss="modal">{{ __('cms.payments.cancel') }}</button>
-                    <button type="button" class="btn btn-danger"
-                            id="confirmDeletePayment">{{ __('cms.payments.delete') }}</button>
-                </div>
-            </div>
-        </div>
-    </div>
-@endsection
-
-@section('js')
-    @php
-        $datatableLang = __('cms.datatables');
-    @endphp
-
-    <script>
-        $(document).ready(function() {
-            const $paymentsTable = $('#payments-table');
-            const $deletePaymentModal = $('#deletePaymentModal');
-            const $confirmDeletePayment = $('#confirmDeletePayment');
-            let paymentToDeleteId = null;
-
-            const toastrOptions = {
-                closeButton: true,
-                progressBar: true,
-                positionClass: 'toast-top-right',
-                timeOut: 5000
-            };
-
-            const table = $paymentsTable.DataTable({
-                processing: true,
-                serverSide: true,
-                ajax: {
-                    url: "{{ route('admin.payments.getData') }}",
-                    data: function (data) {
-                        data.status = $('#filterStatus').val();
-                        data.gateway_id = $('#filterGateway').val();
-                        data.shop_id = $('#filterShop').val();
-                        data.date_from = $('#filterDateFrom').val();
-                        data.date_to = $('#filterDateTo').val();
-                    }
-                },
-                language: @json($datatableLang),
-                columns: [
-                    { data: 'id', name: 'payments.id' },
-                    { data: 'order', name: 'order_id', orderable: false, searchable: false },
-                    { data: 'customer', name: 'customer', orderable: false, searchable: false },
-                    { data: 'shops', name: 'shops', orderable: false, searchable: false },
-                    { data: 'gateway', name: 'gateway_id' },
-                    { data: 'amount', name: 'amount' },
-                    { data: 'status_badge', name: 'status', orderable: false, searchable: false },
-                    { data: 'created_at', name: 'created_at' },
-                    { data: 'transaction_id', name: 'transaction_id' },
-                    { data: 'action', orderable: false, searchable: false }
-                ],
-                order: [[7, 'desc']],
-                pageLength: 10
-            });
-
-            $('#payment-filters').on('submit', function (event) {
-                event.preventDefault();
-                table.ajax.reload();
-            });
-
-            $('#resetFilters').on('click', function () {
-                const form = document.getElementById('payment-filters');
-                form.reset();
-                table.ajax.reload();
-            });
-
-            $(document).on('click', '.btn-view-payment', function() {
-                const url = $(this).data('url');
-                if (url) {
-                    window.location.href = url;
-                }
-            });
-
-            $(document).on('click', '.btn-delete-payment', function() {
-                paymentToDeleteId = $(this).data('id');
-                $deletePaymentModal.modal('show');
-            });
-
-            $deletePaymentModal.on('hidden.bs.modal', function() {
-                paymentToDeleteId = null;
-            });
-
-            $confirmDeletePayment.on('click', function() {
-                if (paymentToDeleteId === null) {
-                    return;
-                }
-
-                $confirmDeletePayment.prop('disabled', true);
-
-                $.ajax({
-                    url: '{{ route('admin.payments.destroy', ':id') }}'.replace(':id', paymentToDeleteId),
-                    type: 'DELETE',
-                    data: {
-                        _token: "{{ csrf_token() }}"
-                    }
-                })
-                    .done(function(response) {
-                        if (response.success) {
-                            table.ajax.reload(null, false);
-                            toastr.success(
-                                response.message || '{{ __('cms.payments.deleted') }}',
-                                '{{ __('cms.payments.success') }}',
-                                toastrOptions
-                            );
-                            $deletePaymentModal.modal('hide');
-                            paymentToDeleteId = null;
-                        } else {
-                            toastr.error(
-                                response.message || '{{ __('cms.payments.delete_error') }}',
-                                '{{ __('cms.payments.delete_error') }}',
-                                toastrOptions
-                            );
-                        }
-                    })
-                    .fail(function() {
-                        toastr.error(
-                            '{{ __('cms.payments.delete_error') }}',
-                            '{{ __('cms.payments.delete_error') }}',
-                            toastrOptions
-                        );
-                    })
-                    .always(function() {
-                        $confirmDeletePayment.prop('disabled', false);
-                    });
-            });
-        });
-    </script>
 @endsection

--- a/resources/views/admin/payments/show.blade.php
+++ b/resources/views/admin/payments/show.blade.php
@@ -1,106 +1,98 @@
 @extends('admin.layouts.admin')
 
 @section('content')
-    <div class="d-flex justify-content-between align-items-center mt-4">
-        <h6 class="mb-0">
-            {{ __('cms.payments.details_title') }}
-            <span class="text-primary">#{{ $payment->id }}</span>
-        </h6>
-        <a href="{{ route('admin.payments.index') }}" class="btn btn-light btn-sm">
-            <i class="bi bi-arrow-left"></i> {{ __('cms.payments.back') }}
-        </a>
-    </div>
+    <x-admin.page-header
+        :title="__('cms.payments.details_heading', ['id' => $payment->id])"
+        :description="__('cms.payments.details_description')"
+    >
+        <x-admin.button-link href="{{ route('admin.payments.index') }}" class="btn-outline">
+            {{ __('cms.payments.back') }}
+        </x-admin.button-link>
+    </x-admin.page-header>
 
-    @php
-        $statusVariants = [
-            'completed' => 'success',
-            'pending' => 'warning text-dark',
-            'failed' => 'danger',
-            'refunded' => 'info text-dark',
-        ];
-        $statusVariant = $statusVariants[$payment->status] ?? 'secondary';
-
-        $statusTranslationKey = 'cms.payments.' . $payment->status;
-        $statusLabel = __($statusTranslationKey);
-        if ($statusLabel === $statusTranslationKey) {
-            $statusLabel = ucfirst($payment->status);
-        }
-
-        $notAvailable = __('cms.payments.not_available');
-    @endphp
-
-    <div class="card mt-3">
-        <div class="card-header card-header-bg text-white">
-            <h6 class="mb-0">{{ __('cms.payments.details_title') }}</h6>
-        </div>
-        <div class="card-body p-0">
-            <div class="table-responsive">
-                <table class="table table-striped mb-0">
-                    <tbody>
-                        <tr>
-                            <th class="w-25">{{ __('cms.payments.id') }}</th>
-                            <td>#{{ $payment->id }}</td>
-                        </tr>
-                        <tr>
-                            <th>{{ __('cms.payments.order') }}</th>
-                            <td>
-                                @if ($payment->order)
-                                    <a href="{{ route('admin.orders.show', $payment->order->id) }}" class="text-decoration-none">
-                                        #{{ $payment->order->id }}
-                                    </a>
-                                @else
-                                    {{ $notAvailable }}
-                                @endif
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>{{ __('cms.payments.user') }}</th>
-                            <td>{{ $payment->customer_display_name ?? $payment->order?->guest_email ?? $notAvailable }}</td>
-                        </tr>
-                        <tr>
-                            <th>{{ __('cms.payments.gateway') }}</th>
-                            <td>{{ $payment->gateway->name ?? $notAvailable }}</td>
-                        </tr>
-                        <tr>
-                            <th>{{ __('cms.payments.shops') }}</th>
-                            <td>
-                                @if (!empty($payment->shop_names))
-                                    <ul class="mb-0 ps-3">
-                                        @foreach ($payment->shop_names as $shopName)
-                                            <li>{{ $shopName }}</li>
-                                        @endforeach
-                                    </ul>
-                                @else
-                                    {{ $notAvailable }}
-                                @endif
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>{{ __('cms.payments.amount') }}</th>
-                            <td>
-                                {{ number_format((float) $payment->amount, 2) }}
-                                @if ($payment->currency)
-                                    <span class="text-muted">{{ $payment->currency }}</span>
-                                @endif
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>{{ __('cms.payments.status') }}</th>
-                            <td>
-                                <span class="badge bg-{{ $statusVariant }}">{{ $statusLabel }}</span>
-                            </td>
-                        </tr>
-                        <tr>
-                            <th>{{ __('cms.payments.transaction_id') }}</th>
-                            <td>{{ $payment->transaction_id ?? $notAvailable }}</td>
-                        </tr>
-                        <tr>
-                            <th>{{ __('cms.payments.created_at') }}</th>
-                            <td>{{ optional($payment->created_at)->format('d M Y, h:i A') ?? $notAvailable }}</td>
-                        </tr>
-                    </tbody>
-                </table>
+    <x-admin.card class="mt-6" :title="__('cms.payments.details_title')">
+        <div class="grid gap-6">
+            <div class="rounded-xl border border-gray-200 bg-white p-4">
+                <p class="text-sm font-medium text-gray-500">{{ __('cms.payments.status') }}</p>
+                <div class="mt-2 flex items-center gap-2">
+                    <span class="text-xl font-semibold text-gray-900">{{ $statusLabel }}</span>
+                    <span class="{{ $statusBadge }}">{{ $statusLabel }}</span>
+                </div>
+                <p class="mt-2 text-xs text-gray-500">{{ __('cms.payments.status_hint') }}</p>
             </div>
+
+            <dl class="grid gap-4 sm:grid-cols-2">
+                <div>
+                    <dt class="text-sm font-medium text-gray-500">{{ __('cms.payments.id') }}</dt>
+                    <dd class="mt-1 text-base font-semibold text-gray-900">#{{ $payment->id }}</dd>
+                </div>
+
+                <div>
+                    <dt class="text-sm font-medium text-gray-500">{{ __('cms.payments.created_at') }}</dt>
+                    <dd class="mt-1 text-base text-gray-900">
+                        {{ optional($payment->created_at)->format('d M Y, h:i A') ?? __('cms.payments.not_available') }}
+                    </dd>
+                </div>
+
+                <div>
+                    <dt class="text-sm font-medium text-gray-500">{{ __('cms.payments.order') }}</dt>
+                    <dd class="mt-1 text-base text-gray-900">
+                        @if ($payment->order)
+                            <a href="{{ route('admin.orders.show', $payment->order) }}" class="text-primary-600 hover:text-primary-700">
+                                #{{ $payment->order->id }}
+                            </a>
+                        @else
+                            {{ __('cms.payments.not_available') }}
+                        @endif
+                    </dd>
+                </div>
+
+                <div>
+                    <dt class="text-sm font-medium text-gray-500">{{ __('cms.payments.user') }}</dt>
+                    <dd class="mt-1 text-base text-gray-900">
+                        {{ $payment->customer_display_name ?? $payment->order?->guest_email ?? __('cms.payments.not_available') }}
+                    </dd>
+                </div>
+
+                <div>
+                    <dt class="text-sm font-medium text-gray-500">{{ __('cms.payments.gateway') }}</dt>
+                    <dd class="mt-1 text-base text-gray-900">
+                        {{ $payment->gateway->name ?? __('cms.payments.not_available') }}
+                    </dd>
+                </div>
+
+                <div>
+                    <dt class="text-sm font-medium text-gray-500">{{ __('cms.payments.transaction_id') }}</dt>
+                    <dd class="mt-1 text-base text-gray-900">
+                        {{ $payment->transaction_id ?? __('cms.payments.not_available') }}
+                    </dd>
+                </div>
+
+                <div>
+                    <dt class="text-sm font-medium text-gray-500">{{ __('cms.payments.amount') }}</dt>
+                    <dd class="mt-1 text-base font-semibold text-gray-900">
+                        {{ number_format((float) $payment->amount, 2) }}
+                        @if ($payment->currency)
+                            <span class="text-sm font-normal text-gray-500">{{ $payment->currency }}</span>
+                        @endif
+                    </dd>
+                </div>
+
+                <div>
+                    <dt class="text-sm font-medium text-gray-500">{{ __('cms.payments.shops') }}</dt>
+                    <dd class="mt-1 text-base text-gray-900">
+                        @if (!empty($payment->shop_names))
+                            <div class="flex flex-wrap gap-2">
+                                @foreach ($payment->shop_names as $shopName)
+                                    <span class="badge badge-gray">{{ $shopName }}</span>
+                                @endforeach
+                            </div>
+                        @else
+                            {{ __('cms.payments.not_available') }}
+                        @endif
+                    </dd>
+                </div>
+            </dl>
         </div>
-    </div>
+    </x-admin.card>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -134,7 +134,6 @@ Route::prefix('admin')->name('admin.')->group(function () {
     Route::post('pages/data', [PageController::class, 'data'])->name('pages.data');
 
     /* payments */
-    Route::get('payments/get-data', [PaymentController::class, 'getData'])->name('payments.getData');
     Route::resource('payments', PaymentController::class)->only(['index', 'destroy', 'show']);
 
     /* Refunds */


### PR DESCRIPTION
## Summary
- replace the admin payments DataTables implementation with server-side filtering, pagination, and summary metrics
- rebuild the payments index and detail views with the new Tailwind component layout and localized copy
- add a dedicated JavaScript module for payment deletion handling and update routes/translations accordingly

## Testing
- npm run build
- php artisan test *(fails: missing vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_68e0432720f88329ada5eb8a9f81b6a1