### PR TITLE
Add admin order stats and translations

### DIFF
--- a/app/Http/Controllers/Admin/OrderController.php
+++ b/app/Http/Controllers/Admin/OrderController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Admin;
 use App\Http\Controllers\Controller;
 use App\Models\Order;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class OrderController extends Controller
 {
@@ -28,6 +29,29 @@ class OrderController extends Controller
 
         $orders = $ordersQuery->paginate(10)->withQueryString();
 
+        $statusCounts = Order::query()
+            ->select('status', DB::raw('COUNT(*) as aggregate'))
+            ->groupBy('status')
+            ->pluck('aggregate', 'status');
+
+        $totalOrders = (int) $statusCounts->sum();
+        $totalRevenue = (float) Order::query()->sum('total_amount');
+        $averageOrderValue = $totalOrders > 0
+            ? round($totalRevenue / $totalOrders, 2)
+            : 0.0;
+
+        $metrics = [
+            'total_orders' => $totalOrders,
+            'total_revenue' => $totalRevenue,
+            'average_order_value' => $averageOrderValue,
+            'status_counts' => [
+                'pending' => (int) ($statusCounts['pending'] ?? 0),
+                'processing' => (int) ($statusCounts['processing'] ?? 0),
+                'completed' => (int) ($statusCounts['completed'] ?? 0),
+                'canceled' => (int) ($statusCounts['canceled'] ?? 0),
+            ],
+        ];
+
         $statusFilterLabels = [
             '' => __('cms.orders.all_orders'),
             'pending' => __('cms.orders.pending_orders'),
@@ -38,6 +62,7 @@ class OrderController extends Controller
 
         return view('admin.orders.index', [
             'orders' => $orders,
+            'metrics' => $metrics,
             'statusFilters' => $statusFilterLabels,
             'currentStatus' => $status,
         ]);

--- a/database/seeders/OrderSeeder.php
+++ b/database/seeders/OrderSeeder.php
@@ -75,6 +75,25 @@ class OrderSeeder extends Seeder
             ];
         }
 
+        if ($productIds->count() >= 1) {
+            $orders[4] = [
+                'guest_email' => 'cancelled-order@example.com',
+                'status' => 'canceled',
+                'created_at' => $now->copy()->subHours(12),
+                'items' => [
+                    ['product_id' => $productIds[0], 'quantity' => 1, 'price' => 45.5],
+                ],
+                'shipping' => [
+                    'name' => 'Guest Three',
+                    'phone' => '+1-202-555-0103',
+                    'address' => '321 Sample Parkway',
+                    'city' => 'Reference City',
+                    'postal_code' => '73301',
+                    'country' => 'United States',
+                ],
+            ];
+        }
+
         foreach ($orders as $id => $payload) {
             $items = collect($payload['items'] ?? []);
             $total = $items->reduce(

--- a/lang/ar/cms.php
+++ b/lang/ar/cms.php
@@ -102,6 +102,7 @@ return [
             'title' => 'بوابات الدفع',
             'list' => 'القائمة',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -798,6 +799,59 @@ return [
         'deleted_success' => 'تم حذف الطلب بنجاح.',
         'deleted_error' => 'فشل في حذف الطلب.',
         'deleted' => 'تم الحذف',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/lang/de/cms.php
+++ b/lang/de/cms.php
@@ -102,6 +102,7 @@ return [
             'title' => 'Zahlungsgateways',
             'list' => 'Liste',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -836,6 +837,59 @@ return [
         'deleted_success' => 'Bestellung erfolgreich gelöscht.',
         'deleted_error' => 'Die Bestellung konnte nicht gelöscht werden.',
         'deleted' => 'Gelöscht',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/lang/en/cms.php
+++ b/lang/en/cms.php
@@ -1287,6 +1287,13 @@ return [
         'total_price' => 'Total Price',
         'action' => 'Actions',
 
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
         // Delete Modal
         'delete_confirm_title' => 'Confirm Delete',
         'delete_confirm_message' => 'Are you sure you want to delete this order?',
@@ -1297,6 +1304,14 @@ return [
         'deleted_success' => 'Order deleted successfully.',
         'deleted_error' => 'Failed to delete the order.',
         'deleted' => 'Deleted',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
 
         // Detail Page
         'details_title' => 'Order Details',

--- a/lang/es/cms.php
+++ b/lang/es/cms.php
@@ -102,6 +102,7 @@ return [
             'title' => 'Pasarelas de Pago',
             'list' => 'Lista',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -823,6 +824,59 @@ return [
         'deleted_success' => 'Pedido eliminado con éxito.',
         'deleted_error' => 'No se pudo eliminar el pedido.',
         'deleted' => 'Eliminado',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/lang/fa/cms.php
+++ b/lang/fa/cms.php
@@ -102,6 +102,7 @@ return [
             'title' => 'درگاه‌های پرداخت',
             'list' => 'لیست',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -860,6 +861,59 @@ return [
         'deleted_success' => 'سفارش با موفقیت حذف شد.',
         'deleted_error' => 'حذف سفارش انجام نشد.',
         'deleted' => 'حذف شد',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/lang/fr/cms.php
+++ b/lang/fr/cms.php
@@ -102,6 +102,7 @@ return [
             'title' => 'Passerelles de paiement',
             'list' => 'Liste',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -822,6 +823,59 @@ return [
         'deleted_success' => 'Commande supprimée avec succès.',
         'deleted_error' => 'Échec de la suppression de la commande.',
         'deleted' => 'Supprimée',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/lang/hi/cms.php
+++ b/lang/hi/cms.php
@@ -102,6 +102,7 @@ return [
             'title' => 'भुगतान गेटवे',
             'list' => 'सूची',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -795,6 +796,59 @@ return [
         'deleted_success' => 'ऑर्डर सफलतापूर्वक हटा दिया गया।',
         'deleted_error' => 'ऑर्डर हटाने में विफल।',
         'deleted' => 'हटा दिया गया',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/lang/id/cms.php
+++ b/lang/id/cms.php
@@ -102,6 +102,7 @@ return [
             'title' => 'Gerbang Pembayaran',
             'list' => 'Daftar',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -799,6 +800,59 @@ return [
         'deleted_success' => 'Pesanan berhasil dihapus.',
         'deleted_error' => 'Gagal menghapus pesanan.',
         'deleted' => 'Dihapus',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/lang/it/cms.php
+++ b/lang/it/cms.php
@@ -102,6 +102,7 @@ return [
             'title' => 'Gateway di Pagamento',
             'list' => 'Elenco',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -796,6 +797,59 @@ return [
         'deleted_success' => 'Ordine eliminato con successo.',
         'deleted_error' => 'Impossibile eliminare l\'ordine.',
         'deleted' => 'Eliminato',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/lang/ja/cms.php
+++ b/lang/ja/cms.php
@@ -102,6 +102,7 @@ return [
             'title' => '決済ゲートウェイ',
             'list' => '一覧',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -859,6 +860,59 @@ return [
         'deleted_success' => '注文は正常に削除されました。',
         'deleted_error' => '注文の削除に失敗しました。',
         'deleted' => '削除済み',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/lang/ko/cms.php
+++ b/lang/ko/cms.php
@@ -102,6 +102,7 @@ return [
             'title' => '결제 게이트웨이',
             'list' => '목록',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -797,6 +798,59 @@ return [
         'deleted_success' => '주문이 성공적으로 삭제되었습니다.',
         'deleted_error' => '주문 삭제에 실패했습니다.',
         'deleted' => '삭제됨',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/lang/nl/cms.php
+++ b/lang/nl/cms.php
@@ -101,6 +101,7 @@ return [
             'title' => 'Betaalgateways',
             'list' => 'Lijst',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -796,6 +797,59 @@ return [
         'deleted_success' => 'Bestelling succesvol verwijderd.',
         'deleted_error' => 'Het verwijderen van de bestelling is mislukt.',
         'deleted' => 'Verwijderd',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/lang/pl/cms.php
+++ b/lang/pl/cms.php
@@ -102,6 +102,7 @@ return [
             'title' => 'Bramki płatności',
             'list' => 'Lista',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -797,6 +798,59 @@ return [
         'deleted_success' => 'Zamówienie zostało pomyślnie usunięte.',
         'deleted_error' => 'Nie udało się usunąć zamówienia.',
         'deleted' => 'Usunięto',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/lang/pt/cms.php
+++ b/lang/pt/cms.php
@@ -101,6 +101,7 @@ return [
             'title' => 'Gateways de Pagamento',
             'list' => 'Lista',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -797,6 +798,59 @@ return [
         'deleted_success' => 'Pedido excluído com sucesso.',
         'deleted_error' => 'Falha ao excluir o pedido.',
         'deleted' => 'Excluído',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/lang/ru/cms.php
+++ b/lang/ru/cms.php
@@ -102,6 +102,7 @@ return [
             'title' => 'Платёжные шлюзы',
             'list' => 'Список',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -859,6 +860,59 @@ return [
         'deleted_success' => 'Заказ успешно удален.',
         'deleted_error' => 'Не удалось удалить заказ.',
         'deleted' => 'Удалено',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/lang/th/cms.php
+++ b/lang/th/cms.php
@@ -102,6 +102,7 @@ return [
             'title' => 'ช่องทางการชำระเงิน',
             'list' => 'รายการ',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -797,6 +798,59 @@ return [
         'deleted_success' => 'ลบคำสั่งซื้อสำเร็จแล้ว',
         'deleted_error' => 'ไม่สามารถลบคำสั่งซื้อได้',
         'deleted' => 'ถูกลบ',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/lang/tr/cms.php
+++ b/lang/tr/cms.php
@@ -102,6 +102,7 @@ return [
             'title' => 'Ödeme Ağ Geçitleri',
             'list' => 'Liste',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -798,6 +799,59 @@ return [
         'deleted_success' => 'Sipariş başarıyla silindi.',
         'deleted_error' => 'Siparişi silme işlemi başarısız oldu.',
         'deleted' => 'Silindi',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/lang/vi/cms.php
+++ b/lang/vi/cms.php
@@ -102,6 +102,7 @@ return [
             'title' => 'Cổng thanh toán',
             'list' => 'Danh sách',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -826,6 +827,59 @@ return [
         'deleted_success' => 'Xóa đơn hàng thành công.',
         'deleted_error' => 'Xóa đơn hàng thất bại.',
         'deleted' => 'Đã xóa',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/lang/zh/cms.php
+++ b/lang/zh/cms.php
@@ -102,6 +102,7 @@ return [
             'title' => '支付网关',
             'list' => '列表',
         ],
+
     ],
 
     'payment_gateways' => [
@@ -861,6 +862,59 @@ return [
         'deleted_success' => '订单删除成功。',
         'deleted_error' => '订单删除失败。',
         'deleted' => '已删除',
+
+        // Filters & Status Labels
+        'all_orders' => 'All Orders',
+        'pending_orders' => 'Pending Orders',
+        'processing_orders' => 'Processing Orders',
+        'completed_orders' => 'Completed Orders',
+        'cancelled_orders' => 'Cancelled Orders',
+
+        // Overview Stats
+        'overview_title' => 'Orders Overview',
+        'overview_description' => 'Track recent orders and revenue at a glance.',
+        'total_orders' => 'Total Orders',
+        'total_revenue' => 'Total Revenue',
+        'average_order_value' => 'Average Order Value',
+        'status_breakdown' => 'Status Breakdown',
+
+        // Detail Page
+        'details_title' => 'Order Details',
+        'summary' => 'Order Summary',
+        'placed_at' => 'Placed At',
+        'total_amount' => 'Total Amount',
+        'items_total' => 'Items Total',
+        'customer_info' => 'Customer Information',
+        'customer_guest' => 'Guest Checkout',
+        'customer_name' => 'Name',
+        'customer_email' => 'Email',
+        'customer_phone' => 'Phone',
+        'guest_email' => 'Guest Email',
+        'shipping' => 'Shipping Address',
+        'shipping_none' => 'No shipping address recorded for this order.',
+        'address' => 'Address',
+        'city' => 'City',
+        'postal_code' => 'Postal Code',
+        'country' => 'Country',
+        'items' => 'Order Items',
+        'product' => 'Product',
+        'sku' => 'SKU',
+        'unit_price' => 'Unit Price',
+        'subtotal' => 'Subtotal',
+        'items_empty' => 'No items attached to this order.',
+        'payments' => 'Payments',
+        'payment_gateway' => 'Gateway',
+        'payment_amount' => 'Amount',
+        'payment_status' => 'Status',
+        'payment_transaction' => 'Transaction ID',
+        'payment_date' => 'Processed At',
+        'payments_none' => 'No payments recorded for this order.',
+        'refunds' => 'Refunds',
+        'refunds_none' => 'No refunds processed for this payment.',
+        'not_available' => 'N/A',
+        'back_to_orders' => 'Back to Orders',
+        'product_missing' => 'Product unavailable',
+
     ],
 
     'attributes' => [

--- a/resources/views/admin/orders/index.blade.php
+++ b/resources/views/admin/orders/index.blade.php
@@ -3,9 +3,98 @@
 @section('content')
     @php
         $deleteTemplate = route('admin.orders.destroy', ['id' => '__ORDER_ID__']);
+        $orderMetrics = [
+            'total_orders' => $metrics['total_orders'] ?? 0,
+            'total_revenue' => $metrics['total_revenue'] ?? 0,
+            'average_order_value' => $metrics['average_order_value'] ?? 0,
+        ];
+        $statusCounts = $metrics['status_counts'] ?? [
+            'pending' => 0,
+            'processing' => 0,
+            'completed' => 0,
+            'canceled' => 0,
+        ];
     @endphp
 
     <x-admin.page-header :title="__('cms.orders.title')" />
+
+    <div class="mt-6 space-y-6">
+        <div>
+            <h2 class="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                {{ __('cms.orders.overview_title') }}
+            </h2>
+            <p class="mt-1 text-sm text-gray-600">
+                {{ __('cms.orders.overview_description') }}
+            </p>
+        </div>
+
+        <div class="grid gap-4 sm:grid-cols-3">
+            <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+                <p class="text-xs font-medium uppercase tracking-wide text-gray-500">
+                    {{ __('cms.orders.total_orders') }}
+                </p>
+                <p class="mt-2 text-2xl font-semibold text-gray-900">
+                    {{ number_format($orderMetrics['total_orders']) }}
+                </p>
+            </div>
+            <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+                <p class="text-xs font-medium uppercase tracking-wide text-gray-500">
+                    {{ __('cms.orders.total_revenue') }}
+                </p>
+                <p class="mt-2 text-2xl font-semibold text-gray-900">
+                    {{ number_format($orderMetrics['total_revenue'], 2) }}
+                </p>
+            </div>
+            <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+                <p class="text-xs font-medium uppercase tracking-wide text-gray-500">
+                    {{ __('cms.orders.average_order_value') }}
+                </p>
+                <p class="mt-2 text-2xl font-semibold text-gray-900">
+                    {{ number_format($orderMetrics['average_order_value'], 2) }}
+                </p>
+            </div>
+        </div>
+
+        <div>
+            <h3 class="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                {{ __('cms.orders.status_breakdown') }}
+            </h3>
+            <div class="mt-3 grid gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+                    <p class="text-xs font-medium uppercase tracking-wide text-gray-500">
+                        {{ __('cms.dashboard.pending_orders') }}
+                    </p>
+                    <p class="mt-2 text-2xl font-semibold text-gray-900">
+                        {{ number_format($statusCounts['pending'] ?? 0) }}
+                    </p>
+                </div>
+                <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+                    <p class="text-xs font-medium uppercase tracking-wide text-gray-500">
+                        {{ __('cms.dashboard.processing_orders') }}
+                    </p>
+                    <p class="mt-2 text-2xl font-semibold text-gray-900">
+                        {{ number_format($statusCounts['processing'] ?? 0) }}
+                    </p>
+                </div>
+                <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+                    <p class="text-xs font-medium uppercase tracking-wide text-gray-500">
+                        {{ __('cms.dashboard.completed_orders') }}
+                    </p>
+                    <p class="mt-2 text-2xl font-semibold text-gray-900">
+                        {{ number_format($statusCounts['completed'] ?? 0) }}
+                    </p>
+                </div>
+                <div class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm">
+                    <p class="text-xs font-medium uppercase tracking-wide text-gray-500">
+                        {{ __('cms.dashboard.cancelled_orders') }}
+                    </p>
+                    <p class="mt-2 text-2xl font-semibold text-gray-900">
+                        {{ number_format($statusCounts['canceled'] ?? 0) }}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
 
     <x-admin.card noMargin class="mt-6">
         <div class="flex flex-wrap items-center gap-3 mb-4">

--- a/tests/Feature/AdminOrdersTranslationTest.php
+++ b/tests/Feature/AdminOrdersTranslationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Support\Facades\Lang;
+use Tests\TestCase;
+
+class AdminOrdersTranslationTest extends TestCase
+{
+    public function test_all_locales_provide_orders_translations(): void
+    {
+        $baseLocale = config('app.fallback_locale', 'en');
+        $expected = Lang::get('cms.orders', [], $baseLocale);
+
+        $this->assertIsArray($expected, 'Expected base order translations to be an array.');
+
+        $locales = collect(glob(lang_path('*'), GLOB_ONLYDIR))
+            ->map(fn (string $path) => basename($path))
+            ->filter(fn (string $locale) => $locale !== $baseLocale)
+            ->values();
+
+        foreach ($locales as $locale) {
+            $translations = Lang::get('cms.orders', [], $locale);
+            $this->assertIsArray($translations, "Orders translations for locale [{$locale}] should be an array.");
+
+            foreach ($expected as $key => $_) {
+                $this->assertArrayHasKey(
+                    $key,
+                    $translations,
+                    sprintf('Locale [%s] is missing the orders translation key [%s].', $locale, $key)
+                );
+            }
+        }
+    }
+}

--- a/tests/Feature/Database/OrderSeederTest.php
+++ b/tests/Feature/Database/OrderSeederTest.php
@@ -20,9 +20,9 @@ class OrderSeederTest extends TestCase
 
         $this->seed(OrderSeeder::class);
 
-        $this->assertSame(3, Order::count());
-        $this->assertSame(3, ShippingAddress::count());
-        $this->assertSame(5, OrderDetail::count());
+        $this->assertSame(4, Order::count());
+        $this->assertSame(4, ShippingAddress::count());
+        $this->assertSame(6, OrderDetail::count());
 
         $this->assertDatabaseHas('shipping_addresses', [
             'name' => 'Guest One',
@@ -38,6 +38,11 @@ class OrderSeederTest extends TestCase
             'name' => 'Showcase Customer',
             'address' => '789 Showcase Boulevard',
         ]);
+
+        $this->assertDatabaseHas('shipping_addresses', [
+            'name' => 'Guest Three',
+            'address' => '321 Sample Parkway',
+        ]);
     }
 
     public function test_order_seeder_is_idempotent(): void
@@ -47,8 +52,8 @@ class OrderSeederTest extends TestCase
         $this->seed(OrderSeeder::class);
         $this->seed(OrderSeeder::class);
 
-        $this->assertSame(3, Order::count());
-        $this->assertSame(3, ShippingAddress::count());
-        $this->assertSame(5, OrderDetail::count());
+        $this->assertSame(4, Order::count());
+        $this->assertSame(4, ShippingAddress::count());
+        $this->assertSame(6, OrderDetail::count());
     }
 }

--- a/tests/Feature/ShowcaseOrderSeedsTest.php
+++ b/tests/Feature/ShowcaseOrderSeedsTest.php
@@ -27,13 +27,18 @@ class ShowcaseOrderSeedsTest extends TestCase
         $this->seed(OrderSeeder::class);
 
         $orders = Order::orderBy('id')->get();
-        $this->assertCount(3, $orders);
-        $this->assertSame([1, 2, 3], $orders->pluck('id')->all());
+        $this->assertCount(4, $orders);
+        $this->assertSame([1, 2, 3, 4], $orders->pluck('id')->all());
 
-        $showcaseOrder = $orders->last();
+        $showcaseOrder = $orders->firstWhere('id', 3);
         $this->assertSame('showcase-order@example.com', $showcaseOrder->guest_email);
         $this->assertSame('processing', $showcaseOrder->status);
         $this->assertEquals(180.75, (float) $showcaseOrder->total_amount);
+
+        $cancelledOrder = $orders->firstWhere('status', 'canceled');
+        $this->assertNotNull($cancelledOrder);
+        $this->assertSame('cancelled-order@example.com', $cancelledOrder->guest_email);
+        $this->assertEquals(45.5, (float) $cancelledOrder->total_amount);
 
         $productIds = DB::table('products')->pluck('id')->take(2);
 
@@ -50,7 +55,7 @@ class ShowcaseOrderSeedsTest extends TestCase
         $this->assertSame(1, $secondItem->quantity);
         $this->assertEquals(60.00, (float) $secondItem->price);
 
-        $this->assertSame(5, OrderDetail::count());
+        $this->assertSame(6, OrderDetail::count());
     }
 
     public function test_payment_seeder_populates_demo_payments_for_showcase_order(): void


### PR DESCRIPTION
## Summary
- surface aggregated order metrics on the admin orders index and expose matching translation strings
- extend the demo order seeder with a cancelled scenario and update coverage tests accordingly
- add a regression test that ensures every locale ships the complete orders translation set

## Testing
- php artisan test *(fails: vendor directory missing and Composer cannot install dependencies in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e0429f9ef883299077fe2287747947