### PR TITLE
Fix syntax error in site settings migration

### DIFF
--- a/database/migrations/2025_02_01_000000_add_extended_fields_to_site_settings_table.php
+++ b/database/migrations/2025_02_01_000000_add_extended_fields_to_site_settings_table.php
@@ -1,10 +1,10 @@
 <?php
 
-use Illuminate\\Database\\Migrations\\Migration;
-use Illuminate\\Database\\Schema\\Blueprint;
-use Illuminate\\Support\\Facades\\Schema;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration
+class AddExtendedFieldsToSiteSettingsTable extends Migration
 {
     /**
      * Run the migrations.
@@ -45,4 +45,4 @@ return new class extends Migration
             ]);
         });
     }
-};
+}


### PR DESCRIPTION
## Summary
- replace the anonymous migration class with a named class definition to avoid PHP parse errors when running migrations

## Testing
- php -l database/migrations/2025_02_01_000000_add_extended_fields_to_site_settings_table.php

------
https://chatgpt.com/codex/tasks/task_e_68e051485c688329aa47e376e327d201