### PR TITLE
Align site settings schema with validation and add coverage

### DIFF
--- a/app/Http/Requests/Admin/SiteSettingUpdateRequest.php
+++ b/app/Http/Requests/Admin/SiteSettingUpdateRequest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace App\\Http\\Requests\\Admin;
+namespace App\Http\Requests\Admin;
 
-use Illuminate\\Foundation\\Http\\FormRequest;
+use Illuminate\Foundation\Http\FormRequest;
 
 class SiteSettingUpdateRequest extends FormRequest
 {

--- a/database/migrations/2025_01_24_064245_create_site_settings_table.php
+++ b/database/migrations/2025_01_24_064245_create_site_settings_table.php
@@ -14,9 +14,9 @@ return new class extends Migration
         Schema::create('site_settings', function (Blueprint $table) {
             $table->id();
             $table->string('site_name'); // The name of the site
-            $table->string('tagline'); // Tagline of the site
-            $table->string('meta_title'); // Meta title for SEO
-            $table->string('meta_description'); // Meta description for SEO
+            $table->string('tagline')->nullable(); // Tagline of the site
+            $table->string('meta_title')->nullable(); // Meta title for SEO
+            $table->text('meta_description')->nullable(); // Meta description for SEO
             $table->string('meta_keywords')->nullable(); // Meta keywords for SEO (optional)
             $table->string('logo')->nullable(); // Path to the site logo image (optional)
             $table->string('favicon')->nullable(); // Path to the favicon image (optional)

--- a/database/migrations/2025_02_01_000000_add_extended_fields_to_site_settings_table.php
+++ b/database/migrations/2025_02_01_000000_add_extended_fields_to_site_settings_table.php
@@ -16,8 +16,8 @@ return new class extends Migration
             $table->string('support_hours')->nullable()->after('support_email');
             $table->boolean('maintenance_mode')->default(false)->after('support_hours');
             $table->text('maintenance_message')->nullable()->after('maintenance_mode');
-            $table->string('primary_color')->nullable()->after('maintenance_message');
-            $table->string('secondary_color')->nullable()->after('primary_color');
+            $table->string('primary_color', 7)->nullable()->after('maintenance_message');
+            $table->string('secondary_color', 7)->nullable()->after('primary_color');
             $table->string('facebook_url')->nullable()->after('secondary_color');
             $table->string('twitter_url')->nullable()->after('facebook_url');
             $table->string('instagram_url')->nullable()->after('twitter_url');

--- a/tests/Feature/AdminSiteSettingsTest.php
+++ b/tests/Feature/AdminSiteSettingsTest.php
@@ -108,4 +108,52 @@ class AdminSiteSettingsTest extends TestCase
         $response->assertRedirect(route('admin.site-settings.edit'));
         $response->assertSessionHasErrors('maintenance_message');
     }
+
+    public function test_invalid_branding_colors_return_validation_errors(): void
+    {
+        $admin = User::factory()->create();
+        SiteSetting::factory()->create([
+            'site_name' => 'Velstore',
+        ]);
+
+        $this->actingAs($admin);
+
+        $payload = [
+            'site_name' => 'Velstore',
+            'primary_color' => 'blue',
+            'secondary_color' => '#12ABZ9',
+        ];
+
+        $response = $this
+            ->from(route('admin.site-settings.edit'))
+            ->put(route('admin.site-settings.update'), $payload);
+
+        $response->assertRedirect(route('admin.site-settings.edit'));
+        $response->assertSessionHasErrors(['primary_color', 'secondary_color']);
+    }
+
+    public function test_invalid_support_contact_emails_are_rejected(): void
+    {
+        $admin = User::factory()->create();
+        SiteSetting::factory()->create([
+            'site_name' => 'Velstore',
+        ]);
+
+        $this->actingAs($admin);
+
+        $payload = [
+            'site_name' => 'Velstore',
+            'contact_email' => 'not-an-email',
+            'support_email' => 'definitely-not-an-email',
+            'primary_color' => '#123456',
+            'secondary_color' => '#abcdef',
+        ];
+
+        $response = $this
+            ->from(route('admin.site-settings.edit'))
+            ->put(route('admin.site-settings.update'), $payload);
+
+        $response->assertRedirect(route('admin.site-settings.edit'));
+        $response->assertSessionHasErrors(['contact_email', 'support_email']);
+    }
 }

--- a/tests/Unit/Http/Requests/Admin/SiteSettingUpdateRequestTest.php
+++ b/tests/Unit/Http/Requests/Admin/SiteSettingUpdateRequestTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Tests\Unit\Http\Requests\Admin;
+
+use App\Http\Requests\Admin\SiteSettingUpdateRequest;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+#[CoversClass(SiteSettingUpdateRequest::class)]
+class SiteSettingUpdateRequestTest extends TestCase
+{
+    #[Test]
+    public function authorize_returns_true_when_user_is_present(): void
+    {
+        $request = new SiteSettingUpdateRequest();
+        $request->setUserResolver(fn () => (object) ['id' => 1]);
+
+        $this->assertTrue($request->authorize());
+    }
+
+    #[Test]
+    public function authorize_returns_false_when_user_is_missing(): void
+    {
+        $request = new SiteSettingUpdateRequest();
+        $request->setUserResolver(fn () => null);
+
+        $this->assertFalse($request->authorize());
+    }
+
+    #[Test]
+    public function rules_define_expected_validation_structure(): void
+    {
+        $request = new SiteSettingUpdateRequest();
+
+        $expectedHexColorRule = ['nullable', 'regex:/^#(?:[0-9a-fA-F]{3}){1,2}$/'];
+
+        $rules = $request->rules();
+
+        $this->assertSame(['required', 'string', 'max:255'], $rules['site_name']);
+        $this->assertSame($expectedHexColorRule, $rules['primary_color']);
+        $this->assertSame($expectedHexColorRule, $rules['secondary_color']);
+        $this->assertContains('required_if:maintenance_mode,1', $rules['maintenance_message']);
+    }
+
+    #[Test]
+    public function rules_cover_all_expected_fields(): void
+    {
+        $request = new SiteSettingUpdateRequest();
+
+        $rules = $request->rules();
+
+        $expectedKeys = [
+            'site_name',
+            'tagline',
+            'meta_title',
+            'meta_description',
+            'meta_keywords',
+            'contact_email',
+            'support_email',
+            'contact_phone',
+            'support_hours',
+            'address',
+            'logo',
+            'favicon',
+            'primary_color',
+            'secondary_color',
+            'facebook_url',
+            'twitter_url',
+            'instagram_url',
+            'linkedin_url',
+            'maintenance_mode',
+            'maintenance_message',
+            'footer_text',
+        ];
+
+        $this->assertSameCanonicalizing($expectedKeys, array_keys($rules));
+    }
+
+    #[Test]
+    public function messages_override_color_validation_feedback(): void
+    {
+        $request = new SiteSettingUpdateRequest();
+
+        $messages = $request->messages();
+
+        $this->assertArrayHasKey('primary_color.regex', $messages);
+        $this->assertArrayHasKey('secondary_color.regex', $messages);
+        $this->assertNotEmpty($messages['primary_color.regex']);
+        $this->assertNotEmpty($messages['secondary_color.regex']);
+    }
+}


### PR DESCRIPTION
## Summary
- allow optional metadata fields in the site settings migration and constrain stored hex colors to 7 characters
- expand admin site settings feature tests with scenarios for invalid color codes and support email validation
- add a unit guard that asserts the form request exposes all expected rule keys

## Testing
- php artisan test *(fails: composer dependencies cannot be installed because GitHub package downloads are blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e04fdd81848329b433ff1761c318b1