### PR TITLE
Fix migration class definition to use anonymous class

### DIFF
--- a/database/migrations/2025_02_01_000000_add_extended_fields_to_site_settings_table.php
+++ b/database/migrations/2025_02_01_000000_add_extended_fields_to_site_settings_table.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class AddExtendedFieldsToSiteSettingsTable extends Migration
+return new class extends Migration
 {
     /**
      * Run the migrations.
@@ -45,4 +45,4 @@ class AddExtendedFieldsToSiteSettingsTable extends Migration
             ]);
         });
     }
-}
+};


### PR DESCRIPTION
## Summary
- convert the extended site settings migration to return an anonymous migration class so Laravel can load it

## Testing
- php artisan migrate --pretend *(fails: missing `vendor/autoload.php` in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e05274d33483298c2065c19d86c717